### PR TITLE
Fix broken `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microblink</groupId>
   <artifactId>blinkreceipt</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.5</version>
   <packaging>aar</packaging>
   <name>BlinkReceipt SDK for Android</name>
   <description>SDK that enables Optical Character Recognition (OCR) based input in your Android application</description>
@@ -29,8 +29,6 @@
       <scope>compile</scope>
       <type>aar</type>
     </dependency>
-  </dependencies>
-   <dependencies>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
@@ -38,8 +36,6 @@
       <scope>compile</scope>
       <type>aar</type>
     </dependency>
-  </dependencies>
-  <dependencies>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>
@@ -47,8 +43,6 @@
       <scope>compile</scope>
       <type>aar</type>
     </dependency>
-  </dependencies>
-  <dependencies>
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>retrofit</artifactId>
@@ -56,8 +50,6 @@
       <scope>compile</scope>
       <type>aar</type>
     </dependency>
-  </dependencies>
-  <dependencies>
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>converter-gson</artifactId>
@@ -65,11 +57,9 @@
       <scope>compile</scope>
       <type>aar</type>
     </dependency>
-  </dependencies>
-  <dependencies>
     <dependency>
       <groupId>com.squareup.okio</groupId>
-      <artifactId>okio:okio</artifactId>
+      <artifactId>okio</artifactId>
       <version>1.13.0</version>
       <scope>compile</scope>
       <type>aar</type>


### PR DESCRIPTION
* Increase build version to `1.0.5` to match what is actually available.
* `pom.xml` can only have one `<dependencies>` section.  Remove unnecessary section breaks to create a single `<dependencies>` tag.
* Fix `okio` dependency reference so it resolves.