### PR TITLE
add mkdocs-macros-plugin

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mkdocs-macros-plugin
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
Adding add mkdocs-macros-plugin to fix the [macros plugin missing error](https://github.com/BlinkReceipt/blinkreceipt-android/actions/runs/15600219972/job/43938614871)