### PR TITLE
Release/2.2.1

### DIFF
--- a/blinkreceipt-account-linking/RELEASE_NOTES.md
+++ b/blinkreceipt-account-linking/RELEASE_NOTES.md
@@ -414,3 +414,6 @@ accountLinkingClient.orders(
 
 ## 2.2.0
 - Stability fixes and improvements
+
+## 2.2.1
+- Stability fixes and improvements

--- a/blinkreceipt-camera-ui/RELEASE_NOTES.md
+++ b/blinkreceipt-camera-ui/RELEASE_NOTES.md
@@ -241,3 +241,6 @@
 
 ## 2.2.0
 - Stability fixes and improvements
+
+## 2.2.1
+- Stability fixes and improvements

--- a/blinkreceipt-camera/RELEASE_NOTES.md
+++ b/blinkreceipt-camera/RELEASE_NOTES.md
@@ -318,3 +318,6 @@
 
 ## 2.2.0
 - Stability fixes and improvements
+
+## 2.2.1
+- Stability fixes and improvements

--- a/blinkreceipt-core/RELEASE_NOTES.md
+++ b/blinkreceipt-core/RELEASE_NOTES.md
@@ -373,3 +373,6 @@
 
 ## 2.2.0
 - Stability fixes and improvements
+
+## 2.2.1
+- Stability fixes and improvements

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/ActivationActivity.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/ActivationActivity.kt
@@ -51,6 +51,7 @@ import com.microblink.camera.ui.CameraCharacteristics
 import com.microblink.camera.ui.CameraRecognizerContract
 import com.microblink.camera.ui.CameraRecognizerOptions
 import com.microblink.camera.ui.CameraRecognizerResults
+import com.microblink.camera.ui.internal.parcelable
 import com.microblink.logcat.LogcatManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/CustomizeAppearanceScreen.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/CustomizeAppearanceScreen.kt
@@ -14,28 +14,43 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.actualplatform.activation.Activation
 import com.actualplatform.activation.theming.ActivationAppearance
+import com.actualplatform.activation.theming.colors
+import com.actualplatform.android.activation.development.ui.themes.CollapsibleSection
+import com.actualplatform.android.activation.development.ui.themes.ErrorModalColorsEditor
+import com.actualplatform.android.activation.development.ui.themes.LoadingColorsEditor
+import com.actualplatform.android.activation.development.ui.themes.LocalDraftActivationTheme
+import com.actualplatform.android.activation.development.ui.themes.MissedEarningsColorsEditor
+import com.actualplatform.android.activation.development.ui.themes.OffersWallColorsEditor
+import com.actualplatform.android.activation.development.ui.themes.ReceiptSummaryColorsEditor
 
 /**
- * Internal/QA tool to edit [ActivationAppearance] per-screen labels at runtime. Mirrors
- * [com.actualplatform.android.activation.development.ui.themes.ThemesAndIconEditorScreen] but
- * simplified to a flat list of labeled fields grouped by SDK screen. On Apply it merges the edited
- * labels into the current [ActivationAppearance] via copy; blank fields become `null` so the SDK
- * uses its bundled localized default. Fields not shown in the UI are preserved unchanged.
+ * Internal/QA tool to edit [ActivationAppearance] at runtime: per-screen labels and per-element
+ * color overrides (one collapsible section per screen scope, mirroring `AppearanceBridge.kt`'s
+ * grouping).
+ *
+ * Blank label fields become `null` so the SDK falls back to its bundled localized default. Color
+ * rows follow the same contract: clearing an override (the trailing close icon) sets it back to
+ * `null`, and each row's "default" preview is computed by calling the real `AppearanceBridge`
+ * function against an empty `Colors()` — so this editor can never drift from what the SDK actually
+ * falls back to. Keys not shown in the UI (reserved iOS-parity keys) are preserved unchanged
+ * because each scope's whole `Colors` object is seeded from the live appearance and only `copy`d.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -44,10 +59,38 @@ internal fun CustomizeAppearanceScreen(
     onReset: () -> Unit,
     onBack: () -> Unit,
 ) {
-    val current = Activation.appearance
-    var scanLabel by remember { mutableStateOf(current.offersWall.labels.scanLabel.orEmpty()) }
-    var scanExtendedLabel by remember {
-        mutableStateOf(current.offersWall.labels.scanExtendedLabel.orEmpty())
+    var scanLabel by remember { mutableStateOf("") }
+    var scanExtendedLabel by remember { mutableStateOf("") }
+
+    // Per-screen appearance color groups — one state object per `ActivationAppearance` scope.
+    var offersWallColors by remember { mutableStateOf(ActivationAppearance.OffersWall.Colors()) }
+    var loadingColors by remember { mutableStateOf(ActivationAppearance.Loading.Colors()) }
+    var errorModalColors by remember { mutableStateOf(ActivationAppearance.ErrorModal.Colors()) }
+    var receiptSummaryColors by remember {
+        mutableStateOf(ActivationAppearance.ReceiptSummary.Colors())
+    }
+    var missedEarningsColors by remember {
+        mutableStateOf(ActivationAppearance.MissedEarnings.Colors())
+    }
+
+    // `Activation.appearance` may still be the SDK default when this composes — DataStore
+    // hydration (kicked off in ActivationActivity.onCreate) reads asynchronously and can land
+    // after navigation. Keep re-syncing from it until the user makes a local edit, rather than
+    // taking a single `.first()` snapshot that could race hydration and cause Apply to persist
+    // (and thus wipe) defaults over a real saved customization.
+    var hasLocalEdits by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { Activation.appearance }.collect { appearance ->
+            if (hasLocalEdits) return@collect
+            scanLabel = appearance.offersWall.labels.scanLabel.orEmpty()
+            scanExtendedLabel = appearance.offersWall.labels.scanExtendedLabel.orEmpty()
+            offersWallColors = appearance.offersWall.colors
+            loadingColors = appearance.loading.colors
+            errorModalColors = appearance.errorModal.colors
+            receiptSummaryColors = appearance.receiptSummary.colors
+            missedEarningsColors = appearance.missedEarnings.colors
+        }
     }
 
     Scaffold(
@@ -70,8 +113,14 @@ internal fun CustomizeAppearanceScreen(
             ) {
                 OutlinedButton(
                     onClick = {
+                        hasLocalEdits = true
                         scanLabel = ""
                         scanExtendedLabel = ""
+                        offersWallColors = ActivationAppearance.OffersWall.Colors()
+                        loadingColors = ActivationAppearance.Loading.Colors()
+                        errorModalColors = ActivationAppearance.ErrorModal.Colors()
+                        receiptSummaryColors = ActivationAppearance.ReceiptSummary.Colors()
+                        missedEarningsColors = ActivationAppearance.MissedEarnings.Colors()
                         onReset()
                     },
                     modifier = Modifier.weight(1f),
@@ -79,14 +128,25 @@ internal fun CustomizeAppearanceScreen(
 
                 Button(
                     onClick = {
-                        val base = Activation.appearance
                         onApply(
-                            base.copy(
-                                offersWall = base.offersWall.copy(
-                                    labels = base.offersWall.labels.copy(
+                            ActivationAppearance(
+                                offersWall = ActivationAppearance.OffersWall(
+                                    colors = offersWallColors,
+                                    labels = ActivationAppearance.OffersWall.Labels(
                                         scanLabel = scanLabel.ifBlank { null },
                                         scanExtendedLabel = scanExtendedLabel.ifBlank { null },
                                     ),
+                                ),
+                                loading = ActivationAppearance.Loading(colors = loadingColors),
+                                errorModal =
+                                ActivationAppearance.ErrorModal(colors = errorModalColors),
+                                receiptSummary =
+                                ActivationAppearance.ReceiptSummary(
+                                    colors = receiptSummaryColors,
+                                ),
+                                missedEarnings =
+                                ActivationAppearance.MissedEarnings(
+                                    colors = missedEarningsColors,
                                 ),
                             ),
                         )
@@ -96,36 +156,98 @@ internal fun CustomizeAppearanceScreen(
             }
         },
     ) { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .verticalScroll(rememberScrollState())
-                .padding(16.dp),
-        ) {
-            Text(
-                text = "Offers Wall",
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(vertical = 8.dp),
-            )
-            OutlinedTextField(
-                value = scanLabel,
-                onValueChange = { scanLabel = it },
-                label = { Text("scanLabel — FAB (collapsed)") },
-                singleLine = true,
+        // `CollapsibleSection`/`ColorPickerRow` paint their chrome from `draftTheme()`; this screen
+        // doesn't let you edit the theme, so it provides the live `Activation.theme` non-editably —
+        // purely so appearance-color rows preview against the SDK's actual active palette.
+        CompositionLocalProvider(LocalDraftActivationTheme provides Activation.theme) {
+            val themeColors = Activation.theme.colors
+
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 4.dp),
-            )
-            OutlinedTextField(
-                value = scanExtendedLabel,
-                onValueChange = { scanExtendedLabel = it },
-                label = { Text("scanExtendedLabel — FAB (extended)") },
-                singleLine = true,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 4.dp),
-            )
+                    .fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
+            ) {
+                CollapsibleSection(title = "Offers Wall", initiallyExpanded = true) {
+                    OutlinedTextField(
+                        value = scanLabel,
+                        onValueChange = {
+                            hasLocalEdits = true
+                            scanLabel = it
+                        },
+                        label = { Text("scanLabel — FAB (collapsed)") },
+                        singleLine = true,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                    )
+                    OutlinedTextField(
+                        value = scanExtendedLabel,
+                        onValueChange = {
+                            hasLocalEdits = true
+                            scanExtendedLabel = it
+                        },
+                        label = { Text("scanExtendedLabel — FAB (extended)") },
+                        singleLine = true,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                    )
+                    OffersWallColorsEditor(
+                        colors = offersWallColors,
+                        theme = themeColors,
+                        onColorsChange = {
+                            hasLocalEdits = true
+                            offersWallColors = it
+                        },
+                    )
+                }
+
+                CollapsibleSection(title = "Loading") {
+                    LoadingColorsEditor(
+                        colors = loadingColors,
+                        theme = themeColors,
+                        onColorsChange = {
+                            hasLocalEdits = true
+                            loadingColors = it
+                        },
+                    )
+                }
+
+                CollapsibleSection(title = "Error Modal") {
+                    ErrorModalColorsEditor(
+                        colors = errorModalColors,
+                        theme = themeColors,
+                        onColorsChange = {
+                            hasLocalEdits = true
+                            errorModalColors = it
+                        },
+                    )
+                }
+
+                CollapsibleSection(title = "Receipt Summary") {
+                    ReceiptSummaryColorsEditor(
+                        colors = receiptSummaryColors,
+                        theme = themeColors,
+                        onColorsChange = {
+                            hasLocalEdits = true
+                            receiptSummaryColors = it
+                        },
+                    )
+                }
+
+                CollapsibleSection(title = "Missed Earnings") {
+                    MissedEarningsColorsEditor(
+                        colors = missedEarningsColors,
+                        theme = themeColors,
+                        onColorsChange = {
+                            hasLocalEdits = true
+                            missedEarningsColors = it
+                        },
+                    )
+                }
+            }
         }
     }
 }

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/AppearanceColorsEditors.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/AppearanceColorsEditors.kt
@@ -1,0 +1,893 @@
+package com.actualplatform.android.activation.development.ui.themes
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.dp
+import com.actualplatform.activation.theming.ActivationAppearance
+import com.actualplatform.activation.theming.ActivationTheme
+import com.actualplatform.activation.theming.adLoadingDefaultDescriptionLabelColor
+import com.actualplatform.activation.theming.adLoadingDefaultTitleLabelColor
+import com.actualplatform.activation.theming.adLoadingLoadingBarBackgroundColor
+import com.actualplatform.activation.theming.adLoadingLoadingBarLabelColor
+import com.actualplatform.activation.theming.adLoadingLoadingBarProgressColor
+import com.actualplatform.activation.theming.errorModalBackButtonLabelColor
+import com.actualplatform.activation.theming.errorModalBackgroundColor
+import com.actualplatform.activation.theming.errorModalDescriptionLabelColor
+import com.actualplatform.activation.theming.errorModalIconBackgroundColor
+import com.actualplatform.activation.theming.errorModalTitleLabelColor
+import com.actualplatform.activation.theming.missedEarningsAddNewFieldLabelColor
+import com.actualplatform.activation.theming.missedEarningsAlertMessageLabelColor
+import com.actualplatform.activation.theming.missedEarningsAlertTitleLabelColor
+import com.actualplatform.activation.theming.missedEarningsEditModalBackgroundColor
+import com.actualplatform.activation.theming.missedEarningsEditModalCancelButtonLabelColor
+import com.actualplatform.activation.theming.missedEarningsEditModalDatePickerColor
+import com.actualplatform.activation.theming.missedEarningsEditModalInputLabelColor
+import com.actualplatform.activation.theming.missedEarningsEditModalInputPlaceholderLabelColor
+import com.actualplatform.activation.theming.missedEarningsEditModalInputValueLabelColor
+import com.actualplatform.activation.theming.missedEarningsEditModalSaveButtonBackgroundColor
+import com.actualplatform.activation.theming.missedEarningsEditModalSaveButtonLabelColor
+import com.actualplatform.activation.theming.missedEarningsEditModalTitleLabelColor
+import com.actualplatform.activation.theming.missedEarningsFieldEditIconColor
+import com.actualplatform.activation.theming.missedEarningsListSectionTitleLabelColor
+import com.actualplatform.activation.theming.missedEarningsModifiedFieldBackgroundColor
+import com.actualplatform.activation.theming.missedEarningsNavigationBarTextColor
+import com.actualplatform.activation.theming.missedEarningsNavigationDescriptionLabelColor
+import com.actualplatform.activation.theming.missedEarningsNavigationEditButtonBackgroundColor
+import com.actualplatform.activation.theming.missedEarningsNavigationEditButtonIconColor
+import com.actualplatform.activation.theming.missedEarningsNavigationSaveButtonBackgroundColor
+import com.actualplatform.activation.theming.missedEarningsNavigationTitleLabelColor
+import com.actualplatform.activation.theming.missedEarningsTripItemLabelColor
+import com.actualplatform.activation.theming.offerBackgroundColor
+import com.actualplatform.activation.theming.offerBrandLabelColor
+import com.actualplatform.activation.theming.offerClipButtonBackgroundColor
+import com.actualplatform.activation.theming.offerClipButtonIconColor
+import com.actualplatform.activation.theming.offerClippedButtonBackgroundColor
+import com.actualplatform.activation.theming.offerClippedButtonIconColor
+import com.actualplatform.activation.theming.offerClippedToastMessageBackgroundColor
+import com.actualplatform.activation.theming.offerClippedToastMessageLabelColor
+import com.actualplatform.activation.theming.offerDetailsClipLabelColor
+import com.actualplatform.activation.theming.offerDetailsEarnRewardLabelColor
+import com.actualplatform.activation.theming.offerDetailsFinePrintLabelColor
+import com.actualplatform.activation.theming.offerDetailsSectionBodyLabelColor
+import com.actualplatform.activation.theming.offerDetailsSectionHeaderTitleLabelColor
+import com.actualplatform.activation.theming.offerDetailsSectionHeaderToggleLabelColor
+import com.actualplatform.activation.theming.offerDetailsSectionNumberedListBadgeBackgroundColor
+import com.actualplatform.activation.theming.offerDetailsSectionNumberedListBadgeLabelColor
+import com.actualplatform.activation.theming.offerDetailsTagChipBorderColor
+import com.actualplatform.activation.theming.offerDetailsTagChipLabelColor
+import com.actualplatform.activation.theming.offerDetailsTitleLabelColor
+import com.actualplatform.activation.theming.offerEligibleMerchantsLabelColor
+import com.actualplatform.activation.theming.offerRewardPointsLabelColor
+import com.actualplatform.activation.theming.offerTagBackgroundColor
+import com.actualplatform.activation.theming.offerTagLabelColor
+import com.actualplatform.activation.theming.offerWallBackgroundColor
+import com.actualplatform.activation.theming.offerWallFloatingButtonBackgroundColor
+import com.actualplatform.activation.theming.offerWallFloatingButtonLabelColor
+import com.actualplatform.activation.theming.offerWallSectionHeaderLabelColor
+import com.actualplatform.activation.theming.offerWallSectionHeaderShowMoreBackgroundColor
+import com.actualplatform.activation.theming.offerWallSectionHeaderShowMoreIconColor
+import com.actualplatform.activation.theming.postScanBoostClaimButtonBackgroundColor
+import com.actualplatform.activation.theming.postScanBoostClaimButtonIconColor
+import com.actualplatform.activation.theming.postScanBoostClaimButtonLabelColor
+import com.actualplatform.activation.theming.postScanBoostDescriptionLabelColor
+import com.actualplatform.activation.theming.postScanBoostSkipButtonLabelColor
+import com.actualplatform.activation.theming.postScanBoostTitleLabelColor
+import com.actualplatform.activation.theming.postScanFooterBackgroundColor
+import com.actualplatform.activation.theming.postScanFooterButtonTitleColor
+import com.actualplatform.activation.theming.postScanHeaderBackgroundColor
+import com.actualplatform.activation.theming.postScanInlineProductTaskBackgroundColor
+import com.actualplatform.activation.theming.postScanInlineProductTaskPointsLabelColor
+import com.actualplatform.activation.theming.postScanInlineProductTaskScanAndEarnBackgroundColor
+import com.actualplatform.activation.theming.postScanInlineProductTaskScanAndEarnLabelColor
+import com.actualplatform.activation.theming.postScanInlineProductTaskWatchAndEarnBackgroundColor
+import com.actualplatform.activation.theming.postScanInlineProductTaskWatchAndEarnLabelColor
+import com.actualplatform.activation.theming.postScanMerchantNameLabelColor
+import com.actualplatform.activation.theming.postScanNoBoostsLabelColor
+import com.actualplatform.activation.theming.postScanPurchaseBackgroundColor
+import com.actualplatform.activation.theming.postScanPurchaseInfoIconColor
+import com.actualplatform.activation.theming.postScanPurchasePointsLabelColor
+import com.actualplatform.activation.theming.postScanQualifiedPurchaseBackgroundColor
+import com.actualplatform.activation.theming.postScanReceiptButtonBackgroundColor
+import com.actualplatform.activation.theming.postScanReceiptButtonIconColor
+import com.actualplatform.activation.theming.postScanSectionHeaderTitleLabelColor
+import com.actualplatform.activation.theming.postScanSuccessDescriptionLabelColor
+import com.actualplatform.activation.theming.postScanSuccessTitleLabelColor
+import com.actualplatform.activation.theming.postScanTotalPointsBackgroundColor
+import com.actualplatform.activation.theming.postScanTotalPointsLabelColor
+import com.actualplatform.activation.theming.postScanTripInfoLabelColor
+import com.actualplatform.activation.theming.purchaseRowLabelColorResolved
+import com.actualplatform.activation.theming.purchaseRowMetadataLabelColorResolved
+import com.actualplatform.activation.theming.storesHeaderBackgroundColor
+import com.actualplatform.activation.theming.storesHeaderTitleLabelColor
+import com.actualplatform.activation.theming.storesListBackgroundColor
+import com.actualplatform.activation.theming.storesListItemBackgroundColor
+import com.actualplatform.activation.theming.storesListItemDefaultIconColor
+import com.actualplatform.activation.theming.storesListItemSubtitleLabelColor
+import com.actualplatform.activation.theming.storesListItemTitleLabelColor
+import com.actualplatform.activation.theming.storesListSectionHeaderLabelColor
+
+/** Neutral placeholder swatch for tint-only-when-set keys, which have no theme-token fallback. */
+private const val UntintedPlaceholder = 0xFF9E9E9EL
+
+private fun androidx.compose.ui.graphics.Color.toLongColor(): Long =
+    toArgb().toLong() and 0xFFFFFFFFL
+
+@Composable
+internal fun OffersWallColorsEditor(
+    colors: ActivationAppearance.OffersWall.Colors,
+    theme: ActivationTheme.Colors,
+    onColorsChange: (ActivationAppearance.OffersWall.Colors) -> Unit,
+) {
+    val empty = ActivationAppearance.OffersWall.Colors()
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        SubSectionHeader("Offer Wall")
+        NullableColorPickerRow(
+            "offerWallBackground",
+            colors.offerWallBackground,
+            empty.offerWallBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerWallBackground = it))
+        }
+        NullableColorPickerRow(
+            "offerWallSectionHeaderLabel",
+            colors.offerWallSectionHeaderLabel,
+            empty.offerWallSectionHeaderLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerWallSectionHeaderLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerWallSectionHeaderShowMoreIcon",
+            colors.offerWallSectionHeaderShowMoreIcon,
+            empty.offerWallSectionHeaderShowMoreIconColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerWallSectionHeaderShowMoreIcon = it))
+        }
+        NullableColorPickerRow(
+            "offerWallSectionHeaderShowMoreBackground",
+            colors.offerWallSectionHeaderShowMoreBackground,
+            empty.offerWallSectionHeaderShowMoreBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerWallSectionHeaderShowMoreBackground = it))
+        }
+        NullableColorPickerRow(
+            "offerWallFloatingButtonBackground",
+            colors.offerWallFloatingButtonBackground,
+            empty.offerWallFloatingButtonBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerWallFloatingButtonBackground = it))
+        }
+        NullableColorPickerRow(
+            "offerWallFloatingButtonLabel",
+            colors.offerWallFloatingButtonLabel,
+            empty.offerWallFloatingButtonLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerWallFloatingButtonLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerWallMoreMerchantsIcon (untinted if unset)",
+            colors.offerWallMoreMerchantsIcon,
+            UntintedPlaceholder,
+        ) {
+            onColorsChange(colors.copy(offerWallMoreMerchantsIcon = it))
+        }
+
+        SubSectionHeader("Offer Card")
+        NullableColorPickerRow(
+            "offerBackground",
+            colors.offerBackground,
+            empty.offerBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerBackground = it))
+        }
+        NullableColorPickerRow(
+            "offerBrandLabel",
+            colors.offerBrandLabel,
+            empty.offerBrandLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerBrandLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerEligibleMerchantsLabel",
+            colors.offerEligibleMerchantsLabel,
+            empty.offerEligibleMerchantsLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerEligibleMerchantsLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerRewardPointsLabel",
+            colors.offerRewardPointsLabel,
+            empty.offerRewardPointsLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerRewardPointsLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerTagLabel",
+            colors.offerTagLabel,
+            empty.offerTagLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerTagLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerTagBackground",
+            colors.offerTagBackground,
+            empty.offerTagBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerTagBackground = it))
+        }
+
+        SubSectionHeader("Clip / Clipped state")
+        NullableColorPickerRow(
+            "offerClipButtonIcon",
+            colors.offerClipButtonIcon,
+            empty.offerClipButtonIconColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerClipButtonIcon = it))
+        }
+        NullableColorPickerRow(
+            "offerClipButtonBackground",
+            colors.offerClipButtonBackground,
+            empty.offerClipButtonBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerClipButtonBackground = it))
+        }
+        NullableColorPickerRow(
+            "offerClippedButtonIcon",
+            colors.offerClippedButtonIcon,
+            empty.offerClippedButtonIconColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerClippedButtonIcon = it))
+        }
+        NullableColorPickerRow(
+            "offerClippedButtonBackground",
+            colors.offerClippedButtonBackground,
+            empty.offerClippedButtonBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerClippedButtonBackground = it))
+        }
+        NullableColorPickerRow(
+            "offerClippedToastMessageLabel",
+            colors.offerClippedToastMessageLabel,
+            empty.offerClippedToastMessageLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerClippedToastMessageLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerClippedToastMessageBackground",
+            colors.offerClippedToastMessageBackground,
+            empty.offerClippedToastMessageBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerClippedToastMessageBackground = it))
+        }
+
+        SubSectionHeader("Offer Details")
+        NullableColorPickerRow(
+            "offerDetailsTitleLabel",
+            colors.offerDetailsTitleLabel,
+            empty.offerDetailsTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerDetailsTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerDetailsEarnRewardLabel",
+            colors.offerDetailsEarnRewardLabel,
+            empty.offerDetailsEarnRewardLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerDetailsEarnRewardLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerDetailsClipLabel",
+            colors.offerDetailsClipLabel,
+            empty.offerDetailsClipLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerDetailsClipLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerDetailsSectionHeaderTitleLabel",
+            colors.offerDetailsSectionHeaderTitleLabel,
+            empty.offerDetailsSectionHeaderTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerDetailsSectionHeaderTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerDetailsSectionHeaderToggleLabel",
+            colors.offerDetailsSectionHeaderToggleLabel,
+            empty.offerDetailsSectionHeaderToggleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerDetailsSectionHeaderToggleLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerDetailsSectionBodyLabel",
+            colors.offerDetailsSectionBodyLabel,
+            empty.offerDetailsSectionBodyLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerDetailsSectionBodyLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerDetailsFinePrintLabel",
+            colors.offerDetailsFinePrintLabel,
+            empty.offerDetailsFinePrintLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerDetailsFinePrintLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerDetailsTagChipLabel",
+            colors.offerDetailsTagChipLabel,
+            empty.offerDetailsTagChipLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerDetailsTagChipLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerDetailsTagChipBorder",
+            colors.offerDetailsTagChipBorder,
+            empty.offerDetailsTagChipBorderColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerDetailsTagChipBorder = it))
+        }
+        NullableColorPickerRow(
+            "offerDetailsSectionNumberedListBadgeLabel",
+            colors.offerDetailsSectionNumberedListBadgeLabel,
+            empty.offerDetailsSectionNumberedListBadgeLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerDetailsSectionNumberedListBadgeLabel = it))
+        }
+        NullableColorPickerRow(
+            "offerDetailsSectionNumberedListBadgeBackground",
+            colors.offerDetailsSectionNumberedListBadgeBackground,
+            empty.offerDetailsSectionNumberedListBadgeBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(offerDetailsSectionNumberedListBadgeBackground = it))
+        }
+
+        SubSectionHeader("Stores")
+        NullableColorPickerRow(
+            "storesHeaderBackground",
+            colors.storesHeaderBackground,
+            empty.storesHeaderBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(storesHeaderBackground = it))
+        }
+        NullableColorPickerRow(
+            "storesHeaderTitleLabel",
+            colors.storesHeaderTitleLabel,
+            empty.storesHeaderTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(storesHeaderTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "storesListBackground",
+            colors.storesListBackground,
+            empty.storesListBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(storesListBackground = it))
+        }
+        NullableColorPickerRow(
+            "storesListSectionHeaderLabel",
+            colors.storesListSectionHeaderLabel,
+            empty.storesListSectionHeaderLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(storesListSectionHeaderLabel = it))
+        }
+        NullableColorPickerRow(
+            "storesListItemBackground",
+            colors.storesListItemBackground,
+            empty.storesListItemBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(storesListItemBackground = it))
+        }
+        NullableColorPickerRow(
+            "storesListItemDefaultIcon",
+            colors.storesListItemDefaultIcon,
+            empty.storesListItemDefaultIconColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(storesListItemDefaultIcon = it))
+        }
+        NullableColorPickerRow(
+            "storesListItemTitleLabel",
+            colors.storesListItemTitleLabel,
+            empty.storesListItemTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(storesListItemTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "storesListItemSubtitleLabel",
+            colors.storesListItemSubtitleLabel,
+            empty.storesListItemSubtitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(storesListItemSubtitleLabel = it))
+        }
+    }
+}
+
+@Composable
+internal fun LoadingColorsEditor(
+    colors: ActivationAppearance.Loading.Colors,
+    theme: ActivationTheme.Colors,
+    onColorsChange: (ActivationAppearance.Loading.Colors) -> Unit,
+) {
+    val empty = ActivationAppearance.Loading.Colors()
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        NullableColorPickerRow(
+            "adLoadingLoadingBarLabel",
+            colors.adLoadingLoadingBarLabel,
+            empty.adLoadingLoadingBarLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(adLoadingLoadingBarLabel = it))
+        }
+        NullableColorPickerRow(
+            "adLoadingLoadingBarBackground",
+            colors.adLoadingLoadingBarBackground,
+            empty.adLoadingLoadingBarBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(adLoadingLoadingBarBackground = it))
+        }
+        NullableColorPickerRow(
+            "adLoadingLoadingBarProgress",
+            colors.adLoadingLoadingBarProgress,
+            empty.adLoadingLoadingBarProgressColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(adLoadingLoadingBarProgress = it))
+        }
+        NullableColorPickerRow(
+            "adLoadingDefaultTitleLabel",
+            colors.adLoadingDefaultTitleLabel,
+            empty.adLoadingDefaultTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(adLoadingDefaultTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "adLoadingDefaultDescriptionLabel",
+            colors.adLoadingDefaultDescriptionLabel,
+            empty.adLoadingDefaultDescriptionLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(adLoadingDefaultDescriptionLabel = it))
+        }
+    }
+}
+
+@Composable
+internal fun ErrorModalColorsEditor(
+    colors: ActivationAppearance.ErrorModal.Colors,
+    theme: ActivationTheme.Colors,
+    onColorsChange: (ActivationAppearance.ErrorModal.Colors) -> Unit,
+) {
+    val empty = ActivationAppearance.ErrorModal.Colors()
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        NullableColorPickerRow(
+            "errorModalBackground",
+            colors.errorModalBackground,
+            empty.errorModalBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(errorModalBackground = it))
+        }
+        NullableColorPickerRow(
+            "errorModalIconBackground",
+            colors.errorModalIconBackground,
+            empty.errorModalIconBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(errorModalIconBackground = it))
+        }
+        NullableColorPickerRow(
+            "errorModalTitleLabel",
+            colors.errorModalTitleLabel,
+            empty.errorModalTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(errorModalTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "errorModalDescriptionLabel",
+            colors.errorModalDescriptionLabel,
+            empty.errorModalDescriptionLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(errorModalDescriptionLabel = it))
+        }
+        NullableColorPickerRow(
+            "errorModalBackButtonLabel",
+            colors.errorModalBackButtonLabel,
+            empty.errorModalBackButtonLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(errorModalBackButtonLabel = it))
+        }
+    }
+}
+
+@Composable
+internal fun ReceiptSummaryColorsEditor(
+    colors: ActivationAppearance.ReceiptSummary.Colors,
+    theme: ActivationTheme.Colors,
+    onColorsChange: (ActivationAppearance.ReceiptSummary.Colors) -> Unit,
+) {
+    val empty = ActivationAppearance.ReceiptSummary.Colors()
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        NullableColorPickerRow(
+            "postScanHeaderBackground",
+            colors.postScanHeaderBackground,
+            empty.postScanHeaderBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanHeaderBackground = it))
+        }
+        NullableColorPickerRow(
+            "postScanTotalPointsBackground",
+            colors.postScanTotalPointsBackground,
+            empty.postScanTotalPointsBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanTotalPointsBackground = it))
+        }
+        NullableColorPickerRow(
+            "postScanTotalPointsLabel",
+            colors.postScanTotalPointsLabel,
+            empty.postScanTotalPointsLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanTotalPointsLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanReceiptButtonIcon",
+            colors.postScanReceiptButtonIcon,
+            empty.postScanReceiptButtonIconColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanReceiptButtonIcon = it))
+        }
+        NullableColorPickerRow(
+            "postScanReceiptButtonBackground",
+            colors.postScanReceiptButtonBackground,
+            empty.postScanReceiptButtonBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanReceiptButtonBackground = it))
+        }
+        NullableColorPickerRow(
+            "postScanFooterBackground",
+            colors.postScanFooterBackground,
+            empty.postScanFooterBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanFooterBackground = it))
+        }
+        NullableColorPickerRow(
+            "postScanFooterButtonTitle",
+            colors.postScanFooterButtonTitle,
+            empty.postScanFooterButtonTitleColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanFooterButtonTitle = it))
+        }
+        NullableColorPickerRow(
+            "postScanMerchantNameLabel",
+            colors.postScanMerchantNameLabel,
+            empty.postScanMerchantNameLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanMerchantNameLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanTripInfoLabel",
+            colors.postScanTripInfoLabel,
+            empty.postScanTripInfoLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanTripInfoLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanSectionHeaderTitleLabel",
+            colors.postScanSectionHeaderTitleLabel,
+            empty.postScanSectionHeaderTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanSectionHeaderTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanNoBoostsLabel",
+            colors.postScanNoBoostsLabel,
+            empty.postScanNoBoostsLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanNoBoostsLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanSuccessTitleLabel",
+            colors.postScanSuccessTitleLabel,
+            empty.postScanSuccessTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanSuccessTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanSuccessDescriptionLabel",
+            colors.postScanSuccessDescriptionLabel,
+            empty.postScanSuccessDescriptionLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanSuccessDescriptionLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanBoostTitleLabel",
+            colors.postScanBoostTitleLabel,
+            empty.postScanBoostTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanBoostTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanBoostDescriptionLabel",
+            colors.postScanBoostDescriptionLabel,
+            empty.postScanBoostDescriptionLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanBoostDescriptionLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanBoostSkipButtonLabel",
+            colors.postScanBoostSkipButtonLabel,
+            empty.postScanBoostSkipButtonLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanBoostSkipButtonLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanBoostClaimButtonLabel",
+            colors.postScanBoostClaimButtonLabel,
+            empty.postScanBoostClaimButtonLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanBoostClaimButtonLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanBoostClaimButtonIcon",
+            colors.postScanBoostClaimButtonIcon,
+            empty.postScanBoostClaimButtonIconColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanBoostClaimButtonIcon = it))
+        }
+        NullableColorPickerRow(
+            "postScanBoostClaimButtonBackground",
+            colors.postScanBoostClaimButtonBackground,
+            empty.postScanBoostClaimButtonBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanBoostClaimButtonBackground = it))
+        }
+        NullableColorPickerRow(
+            "postScanPurchasePointsLabel",
+            colors.postScanPurchasePointsLabel,
+            empty.postScanPurchasePointsLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanPurchasePointsLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanPurchaseBackground",
+            colors.postScanPurchaseBackground,
+            empty.postScanPurchaseBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanPurchaseBackground = it))
+        }
+        NullableColorPickerRow(
+            "postScanQualifiedPurchaseBackground",
+            colors.postScanQualifiedPurchaseBackground,
+            empty.postScanQualifiedPurchaseBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanQualifiedPurchaseBackground = it))
+        }
+        NullableColorPickerRow(
+            "postScanPurchaseInfoIcon",
+            colors.postScanPurchaseInfoIcon,
+            empty.postScanPurchaseInfoIconColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanPurchaseInfoIcon = it))
+        }
+        NullableColorPickerRow(
+            "postScanInlineProductTaskBackground",
+            colors.postScanInlineProductTaskBackground,
+            empty.postScanInlineProductTaskBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanInlineProductTaskBackground = it))
+        }
+        NullableColorPickerRow(
+            "postScanInlineProductTaskScanAndEarnBackground",
+            colors.postScanInlineProductTaskScanAndEarnBackground,
+            empty.postScanInlineProductTaskScanAndEarnBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanInlineProductTaskScanAndEarnBackground = it))
+        }
+        NullableColorPickerRow(
+            "postScanInlineProductTaskWatchAndEarnBackground",
+            colors.postScanInlineProductTaskWatchAndEarnBackground,
+            empty.postScanInlineProductTaskWatchAndEarnBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanInlineProductTaskWatchAndEarnBackground = it))
+        }
+        NullableColorPickerRow(
+            "postScanInlineProductTaskScanAndEarnLabel",
+            colors.postScanInlineProductTaskScanAndEarnLabel,
+            empty.postScanInlineProductTaskScanAndEarnLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanInlineProductTaskScanAndEarnLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanInlineProductTaskWatchAndEarnLabel",
+            colors.postScanInlineProductTaskWatchAndEarnLabel,
+            empty.postScanInlineProductTaskWatchAndEarnLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanInlineProductTaskWatchAndEarnLabel = it))
+        }
+        NullableColorPickerRow(
+            "postScanInlineProductTaskPointsLabel",
+            colors.postScanInlineProductTaskPointsLabel,
+            empty.postScanInlineProductTaskPointsLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(postScanInlineProductTaskPointsLabel = it))
+        }
+        NullableColorPickerRow(
+            "purchaseRowLabelColor",
+            colors.purchaseRowLabelColor,
+            empty.purchaseRowLabelColorResolved(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(purchaseRowLabelColor = it))
+        }
+        NullableColorPickerRow(
+            "purchaseRowMetadataLabelColor",
+            colors.purchaseRowMetadataLabelColor,
+            empty.purchaseRowMetadataLabelColorResolved(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(purchaseRowMetadataLabelColor = it))
+        }
+    }
+}
+
+@Composable
+internal fun MissedEarningsColorsEditor(
+    colors: ActivationAppearance.MissedEarnings.Colors,
+    theme: ActivationTheme.Colors,
+    onColorsChange: (ActivationAppearance.MissedEarnings.Colors) -> Unit,
+) {
+    val empty = ActivationAppearance.MissedEarnings.Colors()
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        NullableColorPickerRow(
+            "missedEarningsNavigationTitleLabel",
+            colors.missedEarningsNavigationTitleLabel,
+            empty.missedEarningsNavigationTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsNavigationTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsNavigationDescriptionLabel",
+            colors.missedEarningsNavigationDescriptionLabel,
+            empty.missedEarningsNavigationDescriptionLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsNavigationDescriptionLabel = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsNavigationBarText",
+            colors.missedEarningsNavigationBarText,
+            empty.missedEarningsNavigationBarTextColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsNavigationBarText = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsNavigationEditButtonIcon",
+            colors.missedEarningsNavigationEditButtonIcon,
+            empty.missedEarningsNavigationEditButtonIconColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsNavigationEditButtonIcon = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsNavigationEditButtonBackground",
+            colors.missedEarningsNavigationEditButtonBackground,
+            empty.missedEarningsNavigationEditButtonBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsNavigationEditButtonBackground = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsNavigationSaveButtonIcon (untinted if unset)",
+            colors.missedEarningsNavigationSaveButtonIcon,
+            UntintedPlaceholder,
+        ) {
+            onColorsChange(colors.copy(missedEarningsNavigationSaveButtonIcon = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsNavigationSaveButtonBackground",
+            colors.missedEarningsNavigationSaveButtonBackground,
+            empty.missedEarningsNavigationSaveButtonBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsNavigationSaveButtonBackground = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsFieldEditIcon",
+            colors.missedEarningsFieldEditIcon,
+            empty.missedEarningsFieldEditIconColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsFieldEditIcon = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsAddNewFieldLabel",
+            colors.missedEarningsAddNewFieldLabel,
+            empty.missedEarningsAddNewFieldLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsAddNewFieldLabel = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsModifiedFieldBackground",
+            colors.missedEarningsModifiedFieldBackground,
+            empty.missedEarningsModifiedFieldBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsModifiedFieldBackground = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsListSectionTitleLabel",
+            colors.missedEarningsListSectionTitleLabel,
+            empty.missedEarningsListSectionTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsListSectionTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsTripItemLabel",
+            colors.missedEarningsTripItemLabel,
+            empty.missedEarningsTripItemLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsTripItemLabel = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsEditModalBackground",
+            colors.missedEarningsEditModalBackground,
+            empty.missedEarningsEditModalBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsEditModalBackground = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsEditModalTitleLabel",
+            colors.missedEarningsEditModalTitleLabel,
+            empty.missedEarningsEditModalTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsEditModalTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsEditModalInputLabel",
+            colors.missedEarningsEditModalInputLabel,
+            empty.missedEarningsEditModalInputLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsEditModalInputLabel = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsEditModalInputPlaceholderLabel",
+            colors.missedEarningsEditModalInputPlaceholderLabel,
+            empty.missedEarningsEditModalInputPlaceholderLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsEditModalInputPlaceholderLabel = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsEditModalInputValueLabel",
+            colors.missedEarningsEditModalInputValueLabel,
+            empty.missedEarningsEditModalInputValueLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsEditModalInputValueLabel = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsEditModalCancelButtonLabel",
+            colors.missedEarningsEditModalCancelButtonLabel,
+            empty.missedEarningsEditModalCancelButtonLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsEditModalCancelButtonLabel = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsEditModalSaveButtonLabel",
+            colors.missedEarningsEditModalSaveButtonLabel,
+            empty.missedEarningsEditModalSaveButtonLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsEditModalSaveButtonLabel = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsEditModalSaveButtonBackground",
+            colors.missedEarningsEditModalSaveButtonBackground,
+            empty.missedEarningsEditModalSaveButtonBackgroundColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsEditModalSaveButtonBackground = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsEditModalDatePicker",
+            colors.missedEarningsEditModalDatePicker,
+            empty.missedEarningsEditModalDatePickerColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsEditModalDatePicker = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsAlertTitleLabel",
+            colors.missedEarningsAlertTitleLabel,
+            empty.missedEarningsAlertTitleLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsAlertTitleLabel = it))
+        }
+        NullableColorPickerRow(
+            "missedEarningsAlertMessageLabel",
+            colors.missedEarningsAlertMessageLabel,
+            empty.missedEarningsAlertMessageLabelColor(theme).toLongColor(),
+        ) {
+            onColorsChange(colors.copy(missedEarningsAlertMessageLabel = it))
+        }
+    }
+}

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/ColorPickerRow.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/ColorPickerRow.kt
@@ -41,7 +41,13 @@ import com.github.skydoves.colorpicker.compose.HsvColorPicker
 import com.github.skydoves.colorpicker.compose.rememberColorPickerController
 
 @Composable
-internal fun ColorPickerRow(label: String, color: Long, onColorChange: (Long) -> Unit) {
+internal fun ColorPickerRow(
+    label: String,
+    color: Long,
+    isDefault: Boolean = false,
+    trailingContent: (@Composable () -> Unit)? = null,
+    onColorChange: (Long) -> Unit,
+) {
     val theme = draftTheme()
     val textPrimary = theme.colors.textPrimary.toComposeColor()
     val textSecondary = theme.colors.textSecondary.toComposeColor()
@@ -56,16 +62,21 @@ internal fun ColorPickerRow(label: String, color: Long, onColorChange: (Long) ->
         val swatchShape = RoundedCornerShape(4.dp)
         Box(
             modifier =
-                Modifier.size(28.dp)
-                    .clip(swatchShape)
-                    .background(Color(color.toInt()))
-                    .border(width = 1.dp, color = border, shape = swatchShape)
+            Modifier.size(28.dp)
+                .clip(swatchShape)
+                .background(Color(color.toInt()))
+                .border(width = 1.dp, color = border, shape = swatchShape),
         )
         Spacer(modifier = Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(text = label, style = theme.typography.bodyMedium, color = textPrimary)
-            Text(text = formatHex(color), style = theme.typography.bodySmall, color = textSecondary)
+            Text(
+                text = if (isDefault) "${formatHex(color)} (default)" else formatHex(color),
+                style = theme.typography.bodySmall,
+                color = textSecondary,
+            )
         }
+        trailingContent?.invoke()
     }
 
     if (dialogOpen) {
@@ -145,10 +156,10 @@ internal fun ColorPickerDialog(
                     val swatchShape = RoundedCornerShape(4.dp)
                     Box(
                         modifier =
-                            Modifier.size(36.dp)
-                                .clip(swatchShape)
-                                .background(Color(currentColor.toInt()))
-                                .border(width = 1.dp, color = border, shape = swatchShape)
+                        Modifier.size(36.dp)
+                            .clip(swatchShape)
+                            .background(Color(currentColor.toInt()))
+                            .border(width = 1.dp, color = border, shape = swatchShape),
                     )
                     Spacer(modifier = Modifier.width(12.dp))
                     OutlinedTextField(
@@ -177,23 +188,23 @@ internal fun ColorPickerDialog(
                         singleLine = true,
                         modifier = Modifier.weight(1f),
                         keyboardOptions =
-                            androidx.compose.foundation.text.KeyboardOptions(
-                                capitalization = KeyboardCapitalization.Characters
-                            ),
+                        androidx.compose.foundation.text.KeyboardOptions(
+                            capitalization = KeyboardCapitalization.Characters,
+                        ),
                         shape = RoundedCornerShape(theme.shapes.sm),
                         colors =
-                            OutlinedTextFieldDefaults.colors(
-                                focusedBorderColor = primary,
-                                unfocusedBorderColor = border,
-                                focusedLabelColor = primary,
-                                unfocusedLabelColor = textSecondary,
-                                cursorColor = primary,
-                                focusedTextColor = textPrimary,
-                                unfocusedTextColor = textPrimary,
-                                errorBorderColor = errorColor,
-                                errorLabelColor = errorColor,
-                                errorTextColor = textPrimary,
-                            ),
+                        OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = primary,
+                            unfocusedBorderColor = border,
+                            focusedLabelColor = primary,
+                            unfocusedLabelColor = textSecondary,
+                            cursorColor = primary,
+                            focusedTextColor = textPrimary,
+                            unfocusedTextColor = textPrimary,
+                            errorBorderColor = errorColor,
+                            errorLabelColor = errorColor,
+                            errorTextColor = textPrimary,
+                        ),
                     )
                 }
             }
@@ -208,8 +219,8 @@ internal fun parseHex(input: String): Long? {
     val cleaned = input.trim().removePrefix("#")
     if (cleaned.length != 6 && cleaned.length != 8) return null
     return runCatching {
-            val parsed = cleaned.toLong(16)
-            if (cleaned.length == 6) 0xFF000000L or parsed else parsed
-        }
+        val parsed = cleaned.toLong(16)
+        if (cleaned.length == 6) 0xFF000000L or parsed else parsed
+    }
         .getOrNull()
 }

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/IconsTabContent.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/IconsTabContent.kt
@@ -88,6 +88,40 @@ internal fun IconsTabContent(theme: ActivationTheme, onThemeChange: (ActivationT
             IconPickerRow("niceScanIcon", theme.icons.niceScanIcon) {
                 onThemeChange(theme.copy(icons = theme.icons.copy(niceScanIcon = it)))
             }
+            IconPickerRow("infoIcon", theme.icons.infoIcon) {
+                onThemeChange(theme.copy(icons = theme.icons.copy(infoIcon = it)))
+            }
+        }
+
+        CollapsibleSection(
+            title = stringResource(R.string.activations_themes_section_missed_earnings),
+        ) {
+            IconPickerRow("editMissedEarning", theme.icons.editMissedEarning) {
+                onThemeChange(theme.copy(icons = theme.icons.copy(editMissedEarning = it)))
+            }
+            IconPickerRow("submitMissedEarnings", theme.icons.submitMissedEarnings) {
+                onThemeChange(theme.copy(icons = theme.icons.copy(submitMissedEarnings = it)))
+            }
+            IconPickerRow("addMissedEarnings", theme.icons.addMissedEarnings) {
+                onThemeChange(theme.copy(icons = theme.icons.copy(addMissedEarnings = it)))
+            }
+            IconPickerRow("reportMissedEarnings", theme.icons.reportMissedEarnings) {
+                onThemeChange(theme.copy(icons = theme.icons.copy(reportMissedEarnings = it)))
+            }
+            IconPickerRow("calendarMissedEarnings", theme.icons.calendarMissedEarnings) {
+                onThemeChange(theme.copy(icons = theme.icons.copy(calendarMissedEarnings = it)))
+            }
+            IconPickerRow(
+                "submitMissedEarningsSuccess",
+                theme.icons.submitMissedEarningsSuccess,
+            ) {
+                onThemeChange(
+                    theme.copy(icons = theme.icons.copy(submitMissedEarningsSuccess = it)),
+                )
+            }
+            IconPickerRow("submitMissedEarningsError", theme.icons.submitMissedEarningsError) {
+                onThemeChange(theme.copy(icons = theme.icons.copy(submitMissedEarningsError = it)))
+            }
         }
     }
 }
@@ -127,10 +161,10 @@ private fun IconPresetGrid(
                         onClick = { presetIcons?.let(onIconsChange) },
                         shape = RoundedCornerShape(active.shapes.sm),
                         colors =
-                            ButtonDefaults.filledTonalButtonColors(
-                                containerColor = if (selected) primary else surfaceAccent,
-                                contentColor = if (selected) textInverse else textPrimary,
-                            ),
+                        ButtonDefaults.filledTonalButtonColors(
+                            containerColor = if (selected) primary else surfaceAccent,
+                            contentColor = if (selected) textInverse else textPrimary,
+                        ),
                     ) {
                         Text(text = preset.label, style = active.typography.labelLarge)
                     }
@@ -143,7 +177,7 @@ private fun IconPresetGrid(
 
 private fun buildPresetIcons(seed: Long, poolBytes: List<ByteArray?>): ActivationTheme.Icons? {
     val rng = Random(seed)
-    val picks = List(13) { poolBytes[rng.nextInt(poolBytes.size)] ?: return null }
+    val picks = List(21) { poolBytes[rng.nextInt(poolBytes.size)] ?: return null }
     fun ic(i: Int) = ActivationIcon.Bytes(picks[i])
     return ActivationTheme.Icons(
         rewardIcon = ic(0),
@@ -159,5 +193,13 @@ private fun buildPresetIcons(seed: Long, poolBytes: List<ByteArray?>): Activatio
         missedEarningsIcon = ic(10),
         boostIcon = ic(11),
         niceScanIcon = ic(12),
+        editMissedEarning = ic(13),
+        submitMissedEarnings = ic(14),
+        addMissedEarnings = ic(15),
+        reportMissedEarnings = ic(16),
+        calendarMissedEarnings = ic(17),
+        submitMissedEarningsSuccess = ic(18),
+        submitMissedEarningsError = ic(19),
+        infoIcon = ic(20),
     )
 }

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/NullableColorPickerRow.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/NullableColorPickerRow.kt
@@ -1,0 +1,43 @@
+package com.actualplatform.android.activation.development.ui.themes
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import com.actualplatform.activation.theming.colors
+
+/**
+ * A [ColorPickerRow] for a `Long?` appearance-color override. `null` shows [default] (the exact
+ * color this element currently renders with, per `AppearanceBridge.kt`) labeled "(default)";
+ * tapping the swatch sets an explicit override, and the trailing close icon (shown only when
+ * overridden) clears it back to `null`.
+ */
+@Composable
+internal fun NullableColorPickerRow(
+    label: String,
+    value: Long?,
+    default: Long,
+    onValueChange: (Long?) -> Unit,
+) {
+    val theme = draftTheme()
+    val textSecondary = theme.colors.textSecondary.toComposeColor()
+
+    ColorPickerRow(
+        label = label,
+        color = value ?: default,
+        isDefault = value == null,
+        trailingContent = {
+            if (value != null) {
+                IconButton(onClick = { onValueChange(null) }) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = "Reset $label to default",
+                        tint = textSecondary,
+                    )
+                }
+            }
+        },
+        onColorChange = { onValueChange(it) },
+    )
+}

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/ThemesAndIconEditorScreen.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/ThemesAndIconEditorScreen.kt
@@ -79,6 +79,7 @@ internal fun ThemesAndIconEditorScreen(
         val textPrimary = theme.colors.textPrimary.toComposeColor()
         val textSecondary = theme.colors.textSecondary.toComposeColor()
         val textInverse = theme.colors.textInverse.toComposeColor()
+        val textOnPrimary = theme.colors.textOnPrimary.toComposeColor()
         val surfaceInverse = theme.colors.surfaceInverse.toComposeColor()
 
         Scaffold(
@@ -113,12 +114,12 @@ internal fun ThemesAndIconEditorScreen(
                         }
                     },
                     colors =
-                        TopAppBarDefaults.topAppBarColors(
-                            containerColor = surface,
-                            titleContentColor = textPrimary,
-                            navigationIconContentColor = textPrimary,
-                            actionIconContentColor = textSecondary,
-                        ),
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = surface,
+                        titleContentColor = textPrimary,
+                        navigationIconContentColor = textPrimary,
+                        actionIconContentColor = textSecondary,
+                    ),
                 )
             },
             bottomBar = {
@@ -128,10 +129,10 @@ internal fun ThemesAndIconEditorScreen(
                             onClick = { onApply(draftTheme) },
                             modifier = Modifier.fillMaxWidth(),
                             colors =
-                                ButtonDefaults.buttonColors(
-                                    containerColor = primary,
-                                    contentColor = textInverse,
-                                ),
+                            ButtonDefaults.buttonColors(
+                                containerColor = primary,
+                                contentColor = textOnPrimary,
+                            ),
                             shape = RoundedCornerShape(theme.shapes.sm),
                         ) {
                             Text(
@@ -187,7 +188,7 @@ internal fun ThemesAndIconEditorScreen(
                     0 ->
                         Column(
                             modifier =
-                                Modifier.fillMaxSize().verticalScroll(themesScroll).padding(16.dp)
+                            Modifier.fillMaxSize().verticalScroll(themesScroll).padding(16.dp),
                         ) {
                             ThemesTabContent(
                                 theme = draftTheme,
@@ -197,9 +198,9 @@ internal fun ThemesAndIconEditorScreen(
                     1 ->
                         Column(
                             modifier =
-                                Modifier.fillMaxSize()
-                                    .verticalScroll(iconsScroll)
-                                    .padding(16.dp)
+                            Modifier.fillMaxSize()
+                                .verticalScroll(iconsScroll)
+                                .padding(16.dp),
                         ) {
                             IconsTabContent(theme = draftTheme, onThemeChange = { draftTheme = it })
                         }

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/ThemesTabContent.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/ThemesTabContent.kt
@@ -58,6 +58,7 @@ internal fun ThemesTabContent(theme: ActivationTheme, onThemeChange: (Activation
     val textPrimary = active.colors.textPrimary.toComposeColor()
     val textSecondary = active.colors.textSecondary.toComposeColor()
     val textInverse = active.colors.textInverse.toComposeColor()
+    val textOnPrimary = active.colors.textOnPrimary.toComposeColor()
     val surface = active.colors.surface.toComposeColor()
     val border = active.colors.border.toComposeColor()
 
@@ -88,19 +89,19 @@ internal fun ThemesTabContent(theme: ActivationTheme, onThemeChange: (Activation
                     onThemeChange(
                         theme.copy(
                             darkColors =
-                                if (enabled) ActivationColorDefaults.darkColors() else theme.lightColors
-                        )
+                            if (enabled) ActivationColorDefaults.darkColors() else theme.lightColors,
+                        ),
                     )
                 },
                 colors =
-                    SwitchDefaults.colors(
-                        checkedThumbColor = textInverse,
-                        checkedTrackColor = primary,
-                        checkedBorderColor = primary,
-                        uncheckedThumbColor = textInverse,
-                        uncheckedTrackColor = textSecondary,
-                        uncheckedBorderColor = textSecondary,
-                    ),
+                SwitchDefaults.colors(
+                    checkedThumbColor = textInverse,
+                    checkedTrackColor = primary,
+                    checkedBorderColor = primary,
+                    uncheckedThumbColor = textInverse,
+                    uncheckedTrackColor = textSecondary,
+                    uncheckedBorderColor = textSecondary,
+                ),
             )
         }
 
@@ -110,7 +111,7 @@ internal fun ThemesTabContent(theme: ActivationTheme, onThemeChange: (Activation
                 val segmentColors =
                     SegmentedButtonDefaults.colors(
                         activeContainerColor = primary,
-                        activeContentColor = textInverse,
+                        activeContentColor = textOnPrimary,
                         activeBorderColor = primary,
                         inactiveContainerColor = surface,
                         inactiveContentColor = textPrimary,
@@ -148,8 +149,11 @@ internal fun ThemesTabContent(theme: ActivationTheme, onThemeChange: (Activation
             colors = editingColors,
             onColorsChange = { updated ->
                 onThemeChange(
-                    if (editingDark) theme.copy(darkColors = updated)
-                    else theme.copy(lightColors = updated)
+                    if (editingDark) {
+                        theme.copy(darkColors = updated)
+                    } else {
+                        theme.copy(lightColors = updated)
+                    },
                 )
             },
         )
@@ -173,6 +177,7 @@ private fun ColorsEditor(
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
         ColorPickerRow("primary", colors.primary) { onColorsChange(colors.copy(primary = it)) }
+        ColorPickerRow("accent", colors.accent) { onColorsChange(colors.copy(accent = it)) }
         ColorPickerRow("secondary", colors.secondary) {
             onColorsChange(colors.copy(secondary = it))
         }
@@ -182,6 +187,9 @@ private fun ColorsEditor(
         ColorPickerRow("surface", colors.surface) { onColorsChange(colors.copy(surface = it)) }
         ColorPickerRow("surfaceAccent", colors.surfaceAccent) {
             onColorsChange(colors.copy(surfaceAccent = it))
+        }
+        ColorPickerRow("surfaceBrand", colors.surfaceBrand) {
+            onColorsChange(colors.copy(surfaceBrand = it))
         }
         ColorPickerRow("surfaceInverse", colors.surfaceInverse) {
             onColorsChange(colors.copy(surfaceInverse = it))
@@ -198,10 +206,20 @@ private fun ColorsEditor(
         ColorPickerRow("textInverse", colors.textInverse) {
             onColorsChange(colors.copy(textInverse = it))
         }
+        ColorPickerRow("textOnPrimary", colors.textOnPrimary) {
+            onColorsChange(colors.copy(textOnPrimary = it))
+        }
+        ColorPickerRow("textOnSecondary", colors.textOnSecondary) {
+            onColorsChange(colors.copy(textOnSecondary = it))
+        }
         ColorPickerRow("success", colors.success) { onColorsChange(colors.copy(success = it)) }
         ColorPickerRow("error", colors.error) { onColorsChange(colors.copy(error = it)) }
         ColorPickerRow("warning", colors.warning) { onColorsChange(colors.copy(warning = it)) }
         ColorPickerRow("border", colors.border) { onColorsChange(colors.copy(border = it)) }
+        ColorPickerRow("tagSurface", colors.tagSurface) {
+            onColorsChange(colors.copy(tagSurface = it))
+        }
+        ColorPickerRow("tagText", colors.tagText) { onColorsChange(colors.copy(tagText = it)) }
     }
 }
 
@@ -230,11 +248,11 @@ private fun ShapesEditor(
             valueRange = 0f..32f,
             steps = 31,
             colors =
-                SliderDefaults.colors(
-                    thumbColor = primary,
-                    activeTrackColor = primary,
-                    inactiveTrackColor = primary.copy(alpha = 0.24f),
-                ),
+            SliderDefaults.colors(
+                thumbColor = primary,
+                activeTrackColor = primary,
+                inactiveTrackColor = primary.copy(alpha = 0.24f),
+            ),
         )
         Text(
             text = stringResource(R.string.activations_themes_section_shapes_instruction),
@@ -262,15 +280,15 @@ private fun ShapesEditor(
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(theme.shapes.sm),
             colors =
-                OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = primary,
-                    unfocusedBorderColor = border,
-                    focusedLabelColor = primary,
-                    unfocusedLabelColor = textSecondary,
-                    cursorColor = primary,
-                    focusedTextColor = textPrimary,
-                    unfocusedTextColor = textPrimary,
-                ),
+            OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = primary,
+                unfocusedBorderColor = border,
+                focusedLabelColor = primary,
+                unfocusedLabelColor = textSecondary,
+                cursorColor = primary,
+                focusedTextColor = textPrimary,
+                unfocusedTextColor = textPrimary,
+            ),
         )
     }
 }
@@ -294,8 +312,11 @@ private fun ShapePreviewRow(shapes: ActivationTheme.Shapes) {
         steps.forEach { step ->
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 val shape =
-                    if (step.isPill) CircleShape
-                    else RoundedCornerShape((shapes.unit * step.multiplier).dp)
+                    if (step.isPill) {
+                        CircleShape
+                    } else {
+                        RoundedCornerShape((shapes.unit * step.multiplier).dp)
+                    }
                 Box(modifier = Modifier.size(48.dp).background(primary, shape))
                 Spacer(Modifier.height(4.dp))
                 Text(text = step.label, style = theme.typography.labelSmall, color = textSecondary)
@@ -324,11 +345,11 @@ private fun TypographyEditor(
             valueRange = 0.6f..1.6f,
             steps = 19,
             colors =
-                SliderDefaults.colors(
-                    thumbColor = primary,
-                    activeTrackColor = primary,
-                    inactiveTrackColor = primary.copy(alpha = 0.24f),
-                ),
+            SliderDefaults.colors(
+                thumbColor = primary,
+                activeTrackColor = primary,
+                inactiveTrackColor = primary.copy(alpha = 0.24f),
+            ),
         )
         Text(
             text = "Multiplied into every text style's font size. 1.0 = design defaults.",
@@ -347,21 +368,21 @@ private fun TypographyRampPreview() {
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(theme.shapes.md),
         colors =
-            CardDefaults.cardColors(
-                containerColor = theme.colors.surfaceAccent.toComposeColor(),
-                contentColor = theme.colors.textSecondary.toComposeColor(),
-            ),
+        CardDefaults.cardColors(
+            containerColor = theme.colors.surfaceAccent.toComposeColor(),
+            contentColor = theme.colors.textSecondary.toComposeColor(),
+        ),
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             typographyRamp.forEach { sample ->
                 Text(
                     text = "${sample.name} — The quick brown fox",
                     style =
-                        theme.typography.bodyLarge.copy(
-                            fontSize = (sample.baseSize * scale).sp,
-                            lineHeight = (sample.baseLine * scale).sp,
-                            fontWeight = sample.weight,
-                        ),
+                    theme.typography.bodyLarge.copy(
+                        fontSize = (sample.baseSize * scale).sp,
+                        lineHeight = (sample.baseLine * scale).sp,
+                        fontWeight = sample.weight,
+                    ),
                 )
                 Spacer(Modifier.height(2.dp))
             }
@@ -376,7 +397,7 @@ private val themePresets =
         ThemePreset("Default") { ActivationTheme() },
         ThemePreset("Magenta + Lime") {
             val colors =
-                ActivationTheme.Colors(
+                ActivationColorDefaults.lightColors(
                     primary = 0xFFFF0080,
                     secondary = 0xFFFF8000,
                     background = 0xFF9400D3,
@@ -397,39 +418,39 @@ private val themePresets =
         ThemePreset("Cyan + Neon Dark") {
             ActivationTheme(
                 lightColors =
-                    ActivationTheme.Colors(
-                        primary = 0xFF00CED1,
-                        secondary = 0xFFFFD700,
-                        background = 0xFF2F4F4F,
-                        surface = 0xFFFFFACD,
-                        surfaceAccent = 0xFFAFEEEE,
-                        surfaceInverse = 0xFF800080,
-                        textPrimary = 0xFF8B4513,
-                        textSecondary = 0xFFD2691E,
-                        textAccent = 0xFFFF4500,
-                        textInverse = 0xFFADFF2F,
-                        success = 0xFFFF1493,
-                        error = 0xFF00FFFF,
-                        warning = 0xFFBA55D3,
-                        border = 0xFF8A2BE2,
-                    ),
+                ActivationColorDefaults.lightColors(
+                    primary = 0xFF00CED1,
+                    secondary = 0xFFFFD700,
+                    background = 0xFF2F4F4F,
+                    surface = 0xFFFFFACD,
+                    surfaceAccent = 0xFFAFEEEE,
+                    surfaceInverse = 0xFF800080,
+                    textPrimary = 0xFF8B4513,
+                    textSecondary = 0xFFD2691E,
+                    textAccent = 0xFFFF4500,
+                    textInverse = 0xFFADFF2F,
+                    success = 0xFFFF1493,
+                    error = 0xFF00FFFF,
+                    warning = 0xFFBA55D3,
+                    border = 0xFF8A2BE2,
+                ),
                 darkColors =
-                    ActivationTheme.Colors(
-                        primary = 0xFF00FF7F,
-                        secondary = 0xFFFF00FF,
-                        background = 0xFF000000,
-                        surface = 0xFF1A0033,
-                        surfaceAccent = 0xFF330066,
-                        surfaceInverse = 0xFFFFE4B5,
-                        textPrimary = 0xFFFFD700,
-                        textSecondary = 0xFF7FFFD4,
-                        textAccent = 0xFFFFA500,
-                        textInverse = 0xFF4B0082,
-                        success = 0xFFFF6347,
-                        error = 0xFF40E0D0,
-                        warning = 0xFF9370DB,
-                        border = 0xFFADFF2F,
-                    ),
+                ActivationColorDefaults.darkColors(
+                    primary = 0xFF00FF7F,
+                    secondary = 0xFFFF00FF,
+                    background = 0xFF000000,
+                    surface = 0xFF1A0033,
+                    surfaceAccent = 0xFF330066,
+                    surfaceInverse = 0xFFFFE4B5,
+                    textPrimary = 0xFFFFD700,
+                    textSecondary = 0xFF7FFFD4,
+                    textAccent = 0xFFFFA500,
+                    textInverse = 0xFF4B0082,
+                    success = 0xFFFF6347,
+                    error = 0xFF40E0D0,
+                    warning = 0xFF9370DB,
+                    border = 0xFFADFF2F,
+                ),
             )
         },
     )
@@ -438,7 +459,7 @@ private val themePresets =
 private fun ThemePresetGrid(theme: ActivationTheme, onThemeChange: (ActivationTheme) -> Unit) {
     val active = draftTheme()
     val primary = active.colors.primary.toComposeColor()
-    val textInverse = active.colors.textInverse.toComposeColor()
+    val textOnPrimary = active.colors.textOnPrimary.toComposeColor()
     val textPrimary = active.colors.textPrimary.toComposeColor()
     val surfaceAccent = active.colors.surfaceAccent.toComposeColor()
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -455,10 +476,10 @@ private fun ThemePresetGrid(theme: ActivationTheme, onThemeChange: (ActivationTh
                         onClick = { onThemeChange(presetTheme) },
                         shape = RoundedCornerShape(active.shapes.sm),
                         colors =
-                            ButtonDefaults.filledTonalButtonColors(
-                                containerColor = if (selected) primary else surfaceAccent,
-                                contentColor = if (selected) textInverse else textPrimary,
-                            ),
+                        ButtonDefaults.filledTonalButtonColors(
+                            containerColor = if (selected) primary else surfaceAccent,
+                            contentColor = if (selected) textOnPrimary else textPrimary,
+                        ),
                     ) {
                         Text(text = preset.label, style = active.typography.labelLarge)
                     }
@@ -484,7 +505,7 @@ private val themeFontOptions =
 private fun ThemeFontPicker(theme: ActivationTheme, onThemeChange: (ActivationTheme) -> Unit) {
     val active = draftTheme()
     val primary = active.colors.primary.toComposeColor()
-    val textInverse = active.colors.textInverse.toComposeColor()
+    val textOnPrimary = active.colors.textOnPrimary.toComposeColor()
     val textPrimary = active.colors.textPrimary.toComposeColor()
     val surfaceAccent = active.colors.surfaceAccent.toComposeColor()
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -501,16 +522,16 @@ private fun ThemeFontPicker(theme: ActivationTheme, onThemeChange: (ActivationTh
                         onClick = {
                             onThemeChange(
                                 theme.copy(
-                                    typography = theme.typography.copy(fontFamily = option.family)
-                                )
+                                    typography = theme.typography.copy(fontFamily = option.family),
+                                ),
                             )
                         },
                         shape = RoundedCornerShape(active.shapes.sm),
                         colors =
-                            ButtonDefaults.filledTonalButtonColors(
-                                containerColor = if (selected) primary else surfaceAccent,
-                                contentColor = if (selected) textInverse else textPrimary,
-                            ),
+                        ButtonDefaults.filledTonalButtonColors(
+                            containerColor = if (selected) primary else surfaceAccent,
+                            contentColor = if (selected) textOnPrimary else textPrimary,
+                        ),
                     ) {
                         Text(text = option.label, style = active.typography.labelLarge)
                     }

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/local/ActivationAppearances.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/local/ActivationAppearances.kt
@@ -3,12 +3,23 @@ package com.actualplatform.android.activation.development.ui.themes.local
 import kotlinx.serialization.Serializable
 import com.actualplatform.activation.theming.ActivationAppearance as ActivationAppearanceModel
 
+/**
+ * Serializable mirror of [ActivationAppearanceModel] for DataStore persistence. Mirrors the SDK
+ * model's nested shape (per-screen scope → `Colors`/`Labels`) so old payloads — which only carried
+ * `offersWall.labels` — keep decoding, and every color key is `Long? = null` matching the SDK's
+ * override contract (null = fall back to the theme token the element already renders with).
+ */
 @Serializable
 internal data class ActivationAppearance(
     val offersWall: OffersWall = OffersWall(),
+    val loading: Loading = Loading(),
+    val errorModal: ErrorModal = ErrorModal(),
+    val receiptSummary: ReceiptSummary = ReceiptSummary(),
+    val missedEarnings: MissedEarnings = MissedEarnings(),
 ) {
     @Serializable
     internal data class OffersWall(
+        val colors: Colors = Colors(),
         val labels: Labels = Labels(),
     ) {
         @Serializable
@@ -16,25 +27,418 @@ internal data class ActivationAppearance(
             val scanLabel: String? = null,
             val scanExtendedLabel: String? = null,
         )
+
+        @Serializable
+        internal data class Colors(
+            // ── Offer Wall ──────────────────────────────────────────────────────
+            val offerWallBackground: Long? = null,
+            val offerWallSectionHeaderLabel: Long? = null,
+            val offerWallSectionHeaderShowMoreIcon: Long? = null,
+            val offerWallSectionHeaderShowMoreBackground: Long? = null,
+            val offerWallFloatingButtonBackground: Long? = null,
+            val offerWallFloatingButtonLabel: Long? = null,
+            val offerWallMoreMerchantsIcon: Long? = null,
+            // ── Offer Card (grid + list variants) ───────────────────────────────
+            val offerBackground: Long? = null,
+            val offerBrandLabel: Long? = null,
+            val offerEligibleMerchantsLabel: Long? = null,
+            val offerRewardPointsLabel: Long? = null,
+            val offerTagLabel: Long? = null,
+            val offerTagBackground: Long? = null,
+            // ── Clip / Clipped state ────────────────────────────────────────────
+            val offerClipButtonIcon: Long? = null,
+            val offerClipButtonBackground: Long? = null,
+            val offerClippedButtonIcon: Long? = null,
+            val offerClippedButtonBackground: Long? = null,
+            val offerClippedToastMessageLabel: Long? = null,
+            val offerClippedToastMessageBackground: Long? = null,
+            // ── Offer Details ───────────────────────────────────────────────────
+            val offerDetailsTitleLabel: Long? = null,
+            val offerDetailsEarnRewardLabel: Long? = null,
+            val offerDetailsClipLabel: Long? = null,
+            val offerDetailsSectionHeaderTitleLabel: Long? = null,
+            val offerDetailsSectionHeaderToggleLabel: Long? = null,
+            val offerDetailsSectionBodyLabel: Long? = null,
+            val offerDetailsFinePrintLabel: Long? = null,
+            val offerDetailsTagChipLabel: Long? = null,
+            val offerDetailsTagChipBorder: Long? = null,
+            val offerDetailsSectionNumberedListBadgeLabel: Long? = null,
+            val offerDetailsSectionNumberedListBadgeBackground: Long? = null,
+            // ── Stores ───────────────────────────────────────────────────────────
+            val storesHeaderBackground: Long? = null,
+            val storesHeaderTitleLabel: Long? = null,
+            val storesListBackground: Long? = null,
+            val storesListSectionHeaderLabel: Long? = null,
+            val storesListItemBackground: Long? = null,
+            val storesListItemDefaultIcon: Long? = null,
+            val storesListItemTitleLabel: Long? = null,
+            val storesListItemSubtitleLabel: Long? = null,
+        )
+    }
+
+    @Serializable
+    internal data class Loading(val colors: Colors = Colors()) {
+        @Serializable
+        internal data class Colors(
+            val adLoadingLoadingBarLabel: Long? = null,
+            val adLoadingLoadingBarBackground: Long? = null,
+            val adLoadingLoadingBarProgress: Long? = null,
+            val adLoadingDefaultTitleLabel: Long? = null,
+            val adLoadingDefaultDescriptionLabel: Long? = null,
+        )
+    }
+
+    @Serializable
+    internal data class ErrorModal(val colors: Colors = Colors()) {
+        @Serializable
+        internal data class Colors(
+            val errorModalBackground: Long? = null,
+            val errorModalIconBackground: Long? = null,
+            val errorModalTitleLabel: Long? = null,
+            val errorModalDescriptionLabel: Long? = null,
+            val errorModalBackButtonLabel: Long? = null,
+        )
+    }
+
+    @Serializable
+    internal data class ReceiptSummary(val colors: Colors = Colors()) {
+        @Serializable
+        internal data class Colors(
+            val postScanHeaderBackground: Long? = null,
+            val postScanTotalPointsBackground: Long? = null,
+            val postScanTotalPointsLabel: Long? = null,
+            val postScanReceiptButtonIcon: Long? = null,
+            val postScanReceiptButtonBackground: Long? = null,
+            val postScanFooterBackground: Long? = null,
+            val postScanFooterButtonTitle: Long? = null,
+            val postScanMerchantNameLabel: Long? = null,
+            val postScanTripInfoLabel: Long? = null,
+            val postScanSectionHeaderTitleLabel: Long? = null,
+            val postScanNoBoostsLabel: Long? = null,
+            val postScanSuccessTitleLabel: Long? = null,
+            val postScanSuccessDescriptionLabel: Long? = null,
+            val postScanBoostTitleLabel: Long? = null,
+            val postScanBoostDescriptionLabel: Long? = null,
+            val postScanBoostSkipButtonLabel: Long? = null,
+            val postScanBoostClaimButtonLabel: Long? = null,
+            val postScanBoostClaimButtonIcon: Long? = null,
+            val postScanBoostClaimButtonBackground: Long? = null,
+            val postScanPurchasePointsLabel: Long? = null,
+            val postScanPurchaseBackground: Long? = null,
+            val postScanQualifiedPurchaseBackground: Long? = null,
+            val postScanPurchaseInfoIcon: Long? = null,
+            val postScanInlineProductTaskBackground: Long? = null,
+            val postScanInlineProductTaskScanAndEarnBackground: Long? = null,
+            val postScanInlineProductTaskWatchAndEarnBackground: Long? = null,
+            val postScanInlineProductTaskScanAndEarnLabel: Long? = null,
+            val postScanInlineProductTaskWatchAndEarnLabel: Long? = null,
+            val postScanInlineProductTaskPointsLabel: Long? = null,
+            val purchaseRowLabelColor: Long? = null,
+            val purchaseRowMetadataLabelColor: Long? = null,
+        )
+    }
+
+    @Serializable
+    internal data class MissedEarnings(val colors: Colors = Colors()) {
+        @Serializable
+        internal data class Colors(
+            val missedEarningsNavigationTitleLabel: Long? = null,
+            val missedEarningsNavigationDescriptionLabel: Long? = null,
+            val missedEarningsNavigationBarText: Long? = null,
+            val missedEarningsNavigationEditButtonIcon: Long? = null,
+            val missedEarningsNavigationEditButtonBackground: Long? = null,
+            val missedEarningsNavigationSaveButtonIcon: Long? = null,
+            val missedEarningsNavigationSaveButtonBackground: Long? = null,
+            val missedEarningsFieldEditIcon: Long? = null,
+            val missedEarningsAddNewFieldLabel: Long? = null,
+            val missedEarningsModifiedFieldBackground: Long? = null,
+            val missedEarningsListSectionTitleLabel: Long? = null,
+            val missedEarningsTripItemLabel: Long? = null,
+            val missedEarningsEditModalBackground: Long? = null,
+            val missedEarningsEditModalTitleLabel: Long? = null,
+            val missedEarningsEditModalInputLabel: Long? = null,
+            val missedEarningsEditModalInputPlaceholderLabel: Long? = null,
+            val missedEarningsEditModalInputValueLabel: Long? = null,
+            val missedEarningsEditModalCancelButtonLabel: Long? = null,
+            val missedEarningsEditModalSaveButtonLabel: Long? = null,
+            val missedEarningsEditModalSaveButtonBackground: Long? = null,
+            val missedEarningsEditModalDatePicker: Long? = null,
+            val missedEarningsAlertTitleLabel: Long? = null,
+            val missedEarningsAlertMessageLabel: Long? = null,
+        )
     }
 }
+
+private fun ActivationAppearanceModel.OffersWall.Colors.toLocal(): ActivationAppearance.OffersWall.Colors =
+    ActivationAppearance.OffersWall.Colors(
+        offerWallBackground = offerWallBackground,
+        offerWallSectionHeaderLabel = offerWallSectionHeaderLabel,
+        offerWallSectionHeaderShowMoreIcon = offerWallSectionHeaderShowMoreIcon,
+        offerWallSectionHeaderShowMoreBackground = offerWallSectionHeaderShowMoreBackground,
+        offerWallFloatingButtonBackground = offerWallFloatingButtonBackground,
+        offerWallFloatingButtonLabel = offerWallFloatingButtonLabel,
+        offerWallMoreMerchantsIcon = offerWallMoreMerchantsIcon,
+        offerBackground = offerBackground,
+        offerBrandLabel = offerBrandLabel,
+        offerEligibleMerchantsLabel = offerEligibleMerchantsLabel,
+        offerRewardPointsLabel = offerRewardPointsLabel,
+        offerTagLabel = offerTagLabel,
+        offerTagBackground = offerTagBackground,
+        offerClipButtonIcon = offerClipButtonIcon,
+        offerClipButtonBackground = offerClipButtonBackground,
+        offerClippedButtonIcon = offerClippedButtonIcon,
+        offerClippedButtonBackground = offerClippedButtonBackground,
+        offerClippedToastMessageLabel = offerClippedToastMessageLabel,
+        offerClippedToastMessageBackground = offerClippedToastMessageBackground,
+        offerDetailsTitleLabel = offerDetailsTitleLabel,
+        offerDetailsEarnRewardLabel = offerDetailsEarnRewardLabel,
+        offerDetailsClipLabel = offerDetailsClipLabel,
+        offerDetailsSectionHeaderTitleLabel = offerDetailsSectionHeaderTitleLabel,
+        offerDetailsSectionHeaderToggleLabel = offerDetailsSectionHeaderToggleLabel,
+        offerDetailsSectionBodyLabel = offerDetailsSectionBodyLabel,
+        offerDetailsFinePrintLabel = offerDetailsFinePrintLabel,
+        offerDetailsTagChipLabel = offerDetailsTagChipLabel,
+        offerDetailsTagChipBorder = offerDetailsTagChipBorder,
+        offerDetailsSectionNumberedListBadgeLabel = offerDetailsSectionNumberedListBadgeLabel,
+        offerDetailsSectionNumberedListBadgeBackground = offerDetailsSectionNumberedListBadgeBackground,
+        storesHeaderBackground = storesHeaderBackground,
+        storesHeaderTitleLabel = storesHeaderTitleLabel,
+        storesListBackground = storesListBackground,
+        storesListSectionHeaderLabel = storesListSectionHeaderLabel,
+        storesListItemBackground = storesListItemBackground,
+        storesListItemDefaultIcon = storesListItemDefaultIcon,
+        storesListItemTitleLabel = storesListItemTitleLabel,
+        storesListItemSubtitleLabel = storesListItemSubtitleLabel,
+    )
+
+private fun ActivationAppearance.OffersWall.Colors.toModel(): ActivationAppearanceModel.OffersWall.Colors =
+    ActivationAppearanceModel.OffersWall.Colors(
+        offerWallBackground = offerWallBackground,
+        offerWallSectionHeaderLabel = offerWallSectionHeaderLabel,
+        offerWallSectionHeaderShowMoreIcon = offerWallSectionHeaderShowMoreIcon,
+        offerWallSectionHeaderShowMoreBackground = offerWallSectionHeaderShowMoreBackground,
+        offerWallFloatingButtonBackground = offerWallFloatingButtonBackground,
+        offerWallFloatingButtonLabel = offerWallFloatingButtonLabel,
+        offerWallMoreMerchantsIcon = offerWallMoreMerchantsIcon,
+        offerBackground = offerBackground,
+        offerBrandLabel = offerBrandLabel,
+        offerEligibleMerchantsLabel = offerEligibleMerchantsLabel,
+        offerRewardPointsLabel = offerRewardPointsLabel,
+        offerTagLabel = offerTagLabel,
+        offerTagBackground = offerTagBackground,
+        offerClipButtonIcon = offerClipButtonIcon,
+        offerClipButtonBackground = offerClipButtonBackground,
+        offerClippedButtonIcon = offerClippedButtonIcon,
+        offerClippedButtonBackground = offerClippedButtonBackground,
+        offerClippedToastMessageLabel = offerClippedToastMessageLabel,
+        offerClippedToastMessageBackground = offerClippedToastMessageBackground,
+        offerDetailsTitleLabel = offerDetailsTitleLabel,
+        offerDetailsEarnRewardLabel = offerDetailsEarnRewardLabel,
+        offerDetailsClipLabel = offerDetailsClipLabel,
+        offerDetailsSectionHeaderTitleLabel = offerDetailsSectionHeaderTitleLabel,
+        offerDetailsSectionHeaderToggleLabel = offerDetailsSectionHeaderToggleLabel,
+        offerDetailsSectionBodyLabel = offerDetailsSectionBodyLabel,
+        offerDetailsFinePrintLabel = offerDetailsFinePrintLabel,
+        offerDetailsTagChipLabel = offerDetailsTagChipLabel,
+        offerDetailsTagChipBorder = offerDetailsTagChipBorder,
+        offerDetailsSectionNumberedListBadgeLabel = offerDetailsSectionNumberedListBadgeLabel,
+        offerDetailsSectionNumberedListBadgeBackground = offerDetailsSectionNumberedListBadgeBackground,
+        storesHeaderBackground = storesHeaderBackground,
+        storesHeaderTitleLabel = storesHeaderTitleLabel,
+        storesListBackground = storesListBackground,
+        storesListSectionHeaderLabel = storesListSectionHeaderLabel,
+        storesListItemBackground = storesListItemBackground,
+        storesListItemDefaultIcon = storesListItemDefaultIcon,
+        storesListItemTitleLabel = storesListItemTitleLabel,
+        storesListItemSubtitleLabel = storesListItemSubtitleLabel,
+    )
+
+private fun ActivationAppearanceModel.Loading.Colors.toLocal(): ActivationAppearance.Loading.Colors =
+    ActivationAppearance.Loading.Colors(
+        adLoadingLoadingBarLabel = adLoadingLoadingBarLabel,
+        adLoadingLoadingBarBackground = adLoadingLoadingBarBackground,
+        adLoadingLoadingBarProgress = adLoadingLoadingBarProgress,
+        adLoadingDefaultTitleLabel = adLoadingDefaultTitleLabel,
+        adLoadingDefaultDescriptionLabel = adLoadingDefaultDescriptionLabel,
+    )
+
+private fun ActivationAppearance.Loading.Colors.toModel(): ActivationAppearanceModel.Loading.Colors =
+    ActivationAppearanceModel.Loading.Colors(
+        adLoadingLoadingBarLabel = adLoadingLoadingBarLabel,
+        adLoadingLoadingBarBackground = adLoadingLoadingBarBackground,
+        adLoadingLoadingBarProgress = adLoadingLoadingBarProgress,
+        adLoadingDefaultTitleLabel = adLoadingDefaultTitleLabel,
+        adLoadingDefaultDescriptionLabel = adLoadingDefaultDescriptionLabel,
+    )
+
+private fun ActivationAppearanceModel.ErrorModal.Colors.toLocal(): ActivationAppearance.ErrorModal.Colors =
+    ActivationAppearance.ErrorModal.Colors(
+        errorModalBackground = errorModalBackground,
+        errorModalIconBackground = errorModalIconBackground,
+        errorModalTitleLabel = errorModalTitleLabel,
+        errorModalDescriptionLabel = errorModalDescriptionLabel,
+        errorModalBackButtonLabel = errorModalBackButtonLabel,
+    )
+
+private fun ActivationAppearance.ErrorModal.Colors.toModel(): ActivationAppearanceModel.ErrorModal.Colors =
+    ActivationAppearanceModel.ErrorModal.Colors(
+        errorModalBackground = errorModalBackground,
+        errorModalIconBackground = errorModalIconBackground,
+        errorModalTitleLabel = errorModalTitleLabel,
+        errorModalDescriptionLabel = errorModalDescriptionLabel,
+        errorModalBackButtonLabel = errorModalBackButtonLabel,
+    )
+
+private fun ActivationAppearanceModel.ReceiptSummary.Colors.toLocal(): ActivationAppearance.ReceiptSummary.Colors =
+    ActivationAppearance.ReceiptSummary.Colors(
+        postScanHeaderBackground = postScanHeaderBackground,
+        postScanTotalPointsBackground = postScanTotalPointsBackground,
+        postScanTotalPointsLabel = postScanTotalPointsLabel,
+        postScanReceiptButtonIcon = postScanReceiptButtonIcon,
+        postScanReceiptButtonBackground = postScanReceiptButtonBackground,
+        postScanFooterBackground = postScanFooterBackground,
+        postScanFooterButtonTitle = postScanFooterButtonTitle,
+        postScanMerchantNameLabel = postScanMerchantNameLabel,
+        postScanTripInfoLabel = postScanTripInfoLabel,
+        postScanSectionHeaderTitleLabel = postScanSectionHeaderTitleLabel,
+        postScanNoBoostsLabel = postScanNoBoostsLabel,
+        postScanSuccessTitleLabel = postScanSuccessTitleLabel,
+        postScanSuccessDescriptionLabel = postScanSuccessDescriptionLabel,
+        postScanBoostTitleLabel = postScanBoostTitleLabel,
+        postScanBoostDescriptionLabel = postScanBoostDescriptionLabel,
+        postScanBoostSkipButtonLabel = postScanBoostSkipButtonLabel,
+        postScanBoostClaimButtonLabel = postScanBoostClaimButtonLabel,
+        postScanBoostClaimButtonIcon = postScanBoostClaimButtonIcon,
+        postScanBoostClaimButtonBackground = postScanBoostClaimButtonBackground,
+        postScanPurchasePointsLabel = postScanPurchasePointsLabel,
+        postScanPurchaseBackground = postScanPurchaseBackground,
+        postScanQualifiedPurchaseBackground = postScanQualifiedPurchaseBackground,
+        postScanPurchaseInfoIcon = postScanPurchaseInfoIcon,
+        postScanInlineProductTaskBackground = postScanInlineProductTaskBackground,
+        postScanInlineProductTaskScanAndEarnBackground = postScanInlineProductTaskScanAndEarnBackground,
+        postScanInlineProductTaskWatchAndEarnBackground = postScanInlineProductTaskWatchAndEarnBackground,
+        postScanInlineProductTaskScanAndEarnLabel = postScanInlineProductTaskScanAndEarnLabel,
+        postScanInlineProductTaskWatchAndEarnLabel = postScanInlineProductTaskWatchAndEarnLabel,
+        postScanInlineProductTaskPointsLabel = postScanInlineProductTaskPointsLabel,
+        purchaseRowLabelColor = purchaseRowLabelColor,
+        purchaseRowMetadataLabelColor = purchaseRowMetadataLabelColor,
+    )
+
+private fun ActivationAppearance.ReceiptSummary.Colors.toModel(): ActivationAppearanceModel.ReceiptSummary.Colors =
+    ActivationAppearanceModel.ReceiptSummary.Colors(
+        postScanHeaderBackground = postScanHeaderBackground,
+        postScanTotalPointsBackground = postScanTotalPointsBackground,
+        postScanTotalPointsLabel = postScanTotalPointsLabel,
+        postScanReceiptButtonIcon = postScanReceiptButtonIcon,
+        postScanReceiptButtonBackground = postScanReceiptButtonBackground,
+        postScanFooterBackground = postScanFooterBackground,
+        postScanFooterButtonTitle = postScanFooterButtonTitle,
+        postScanMerchantNameLabel = postScanMerchantNameLabel,
+        postScanTripInfoLabel = postScanTripInfoLabel,
+        postScanSectionHeaderTitleLabel = postScanSectionHeaderTitleLabel,
+        postScanNoBoostsLabel = postScanNoBoostsLabel,
+        postScanSuccessTitleLabel = postScanSuccessTitleLabel,
+        postScanSuccessDescriptionLabel = postScanSuccessDescriptionLabel,
+        postScanBoostTitleLabel = postScanBoostTitleLabel,
+        postScanBoostDescriptionLabel = postScanBoostDescriptionLabel,
+        postScanBoostSkipButtonLabel = postScanBoostSkipButtonLabel,
+        postScanBoostClaimButtonLabel = postScanBoostClaimButtonLabel,
+        postScanBoostClaimButtonIcon = postScanBoostClaimButtonIcon,
+        postScanBoostClaimButtonBackground = postScanBoostClaimButtonBackground,
+        postScanPurchasePointsLabel = postScanPurchasePointsLabel,
+        postScanPurchaseBackground = postScanPurchaseBackground,
+        postScanQualifiedPurchaseBackground = postScanQualifiedPurchaseBackground,
+        postScanPurchaseInfoIcon = postScanPurchaseInfoIcon,
+        postScanInlineProductTaskBackground = postScanInlineProductTaskBackground,
+        postScanInlineProductTaskScanAndEarnBackground = postScanInlineProductTaskScanAndEarnBackground,
+        postScanInlineProductTaskWatchAndEarnBackground = postScanInlineProductTaskWatchAndEarnBackground,
+        postScanInlineProductTaskScanAndEarnLabel = postScanInlineProductTaskScanAndEarnLabel,
+        postScanInlineProductTaskWatchAndEarnLabel = postScanInlineProductTaskWatchAndEarnLabel,
+        postScanInlineProductTaskPointsLabel = postScanInlineProductTaskPointsLabel,
+        purchaseRowLabelColor = purchaseRowLabelColor,
+        purchaseRowMetadataLabelColor = purchaseRowMetadataLabelColor,
+    )
+
+private fun ActivationAppearanceModel.MissedEarnings.Colors.toLocal(): ActivationAppearance.MissedEarnings.Colors =
+    ActivationAppearance.MissedEarnings.Colors(
+        missedEarningsNavigationTitleLabel = missedEarningsNavigationTitleLabel,
+        missedEarningsNavigationDescriptionLabel = missedEarningsNavigationDescriptionLabel,
+        missedEarningsNavigationBarText = missedEarningsNavigationBarText,
+        missedEarningsNavigationEditButtonIcon = missedEarningsNavigationEditButtonIcon,
+        missedEarningsNavigationEditButtonBackground = missedEarningsNavigationEditButtonBackground,
+        missedEarningsNavigationSaveButtonIcon = missedEarningsNavigationSaveButtonIcon,
+        missedEarningsNavigationSaveButtonBackground = missedEarningsNavigationSaveButtonBackground,
+        missedEarningsFieldEditIcon = missedEarningsFieldEditIcon,
+        missedEarningsAddNewFieldLabel = missedEarningsAddNewFieldLabel,
+        missedEarningsModifiedFieldBackground = missedEarningsModifiedFieldBackground,
+        missedEarningsListSectionTitleLabel = missedEarningsListSectionTitleLabel,
+        missedEarningsTripItemLabel = missedEarningsTripItemLabel,
+        missedEarningsEditModalBackground = missedEarningsEditModalBackground,
+        missedEarningsEditModalTitleLabel = missedEarningsEditModalTitleLabel,
+        missedEarningsEditModalInputLabel = missedEarningsEditModalInputLabel,
+        missedEarningsEditModalInputPlaceholderLabel = missedEarningsEditModalInputPlaceholderLabel,
+        missedEarningsEditModalInputValueLabel = missedEarningsEditModalInputValueLabel,
+        missedEarningsEditModalCancelButtonLabel = missedEarningsEditModalCancelButtonLabel,
+        missedEarningsEditModalSaveButtonLabel = missedEarningsEditModalSaveButtonLabel,
+        missedEarningsEditModalSaveButtonBackground = missedEarningsEditModalSaveButtonBackground,
+        missedEarningsEditModalDatePicker = missedEarningsEditModalDatePicker,
+        missedEarningsAlertTitleLabel = missedEarningsAlertTitleLabel,
+        missedEarningsAlertMessageLabel = missedEarningsAlertMessageLabel,
+    )
+
+private fun ActivationAppearance.MissedEarnings.Colors.toModel(): ActivationAppearanceModel.MissedEarnings.Colors =
+    ActivationAppearanceModel.MissedEarnings.Colors(
+        missedEarningsNavigationTitleLabel = missedEarningsNavigationTitleLabel,
+        missedEarningsNavigationDescriptionLabel = missedEarningsNavigationDescriptionLabel,
+        missedEarningsNavigationBarText = missedEarningsNavigationBarText,
+        missedEarningsNavigationEditButtonIcon = missedEarningsNavigationEditButtonIcon,
+        missedEarningsNavigationEditButtonBackground = missedEarningsNavigationEditButtonBackground,
+        missedEarningsNavigationSaveButtonIcon = missedEarningsNavigationSaveButtonIcon,
+        missedEarningsNavigationSaveButtonBackground = missedEarningsNavigationSaveButtonBackground,
+        missedEarningsFieldEditIcon = missedEarningsFieldEditIcon,
+        missedEarningsAddNewFieldLabel = missedEarningsAddNewFieldLabel,
+        missedEarningsModifiedFieldBackground = missedEarningsModifiedFieldBackground,
+        missedEarningsListSectionTitleLabel = missedEarningsListSectionTitleLabel,
+        missedEarningsTripItemLabel = missedEarningsTripItemLabel,
+        missedEarningsEditModalBackground = missedEarningsEditModalBackground,
+        missedEarningsEditModalTitleLabel = missedEarningsEditModalTitleLabel,
+        missedEarningsEditModalInputLabel = missedEarningsEditModalInputLabel,
+        missedEarningsEditModalInputPlaceholderLabel = missedEarningsEditModalInputPlaceholderLabel,
+        missedEarningsEditModalInputValueLabel = missedEarningsEditModalInputValueLabel,
+        missedEarningsEditModalCancelButtonLabel = missedEarningsEditModalCancelButtonLabel,
+        missedEarningsEditModalSaveButtonLabel = missedEarningsEditModalSaveButtonLabel,
+        missedEarningsEditModalSaveButtonBackground = missedEarningsEditModalSaveButtonBackground,
+        missedEarningsEditModalDatePicker = missedEarningsEditModalDatePicker,
+        missedEarningsAlertTitleLabel = missedEarningsAlertTitleLabel,
+        missedEarningsAlertMessageLabel = missedEarningsAlertMessageLabel,
+    )
 
 internal fun ActivationAppearanceModel.toLocal(): ActivationAppearance =
     ActivationAppearance(
         offersWall = ActivationAppearance.OffersWall(
+            colors = offersWall.colors.toLocal(),
             labels = ActivationAppearance.OffersWall.Labels(
                 scanLabel = offersWall.labels.scanLabel,
                 scanExtendedLabel = offersWall.labels.scanExtendedLabel,
             ),
         ),
+        loading = ActivationAppearance.Loading(colors = loading.colors.toLocal()),
+        errorModal = ActivationAppearance.ErrorModal(colors = errorModal.colors.toLocal()),
+        receiptSummary = ActivationAppearance.ReceiptSummary(colors = receiptSummary.colors.toLocal()),
+        missedEarnings = ActivationAppearance.MissedEarnings(colors = missedEarnings.colors.toLocal()),
     )
 
 internal fun ActivationAppearance.toModel(): ActivationAppearanceModel =
     ActivationAppearanceModel(
         offersWall = ActivationAppearanceModel.OffersWall(
+            colors = offersWall.colors.toModel(),
             labels = ActivationAppearanceModel.OffersWall.Labels(
                 scanLabel = offersWall.labels.scanLabel,
                 scanExtendedLabel = offersWall.labels.scanExtendedLabel,
             ),
         ),
+        loading = ActivationAppearanceModel.Loading(colors = loading.colors.toModel()),
+        errorModal = ActivationAppearanceModel.ErrorModal(colors = errorModal.colors.toModel()),
+        receiptSummary = ActivationAppearanceModel.ReceiptSummary(colors = receiptSummary.colors.toModel()),
+        missedEarnings = ActivationAppearanceModel.MissedEarnings(colors = missedEarnings.colors.toModel()),
     )

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/local/ActivationThemes.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/local/ActivationThemes.kt
@@ -32,6 +32,15 @@ internal data class ActivationTheme(
         val error: Long = 0xFFF43F5EL,
         val warning: Long = 0xFFFCA355L,
         val border: Long = 0xFFE5E7EBL,
+        // New tokens default to their parent token (mirroring ActivationColorDefaults' cascade)
+        // so payloads persisted before these fields existed decode with the values the SDK
+        // would derive rather than resetting to a literal.
+        val accent: Long = primary,
+        val surfaceBrand: Long = primary,
+        val textOnPrimary: Long = textInverse,
+        val textOnSecondary: Long = textInverse,
+        val tagSurface: Long = surfaceAccent,
+        val tagText: Long = textAccent,
     )
 
     @Serializable
@@ -61,6 +70,14 @@ internal data class ActivationTheme(
         val missedEarningsIcon: ActivationIcon? = null,
         val boostIcon: ActivationIcon? = null,
         val niceScanIcon: ActivationIcon? = null,
+        val editMissedEarning: ActivationIcon? = null,
+        val submitMissedEarnings: ActivationIcon? = null,
+        val addMissedEarnings: ActivationIcon? = null,
+        val reportMissedEarnings: ActivationIcon? = null,
+        val calendarMissedEarnings: ActivationIcon? = null,
+        val submitMissedEarningsSuccess: ActivationIcon? = null,
+        val submitMissedEarningsError: ActivationIcon? = null,
+        val infoIcon: ActivationIcon? = null,
     )
 }
 
@@ -80,6 +97,12 @@ private fun ActivationThemeModel.Colors.toLocal(): ActivationTheme.Colors =
         error = error,
         warning = warning,
         border = border,
+        accent = accent,
+        surfaceBrand = surfaceBrand,
+        textOnPrimary = textOnPrimary,
+        textOnSecondary = textOnSecondary,
+        tagSurface = tagSurface,
+        tagText = tagText,
     )
 
 private fun ActivationTheme.Colors.toModel(): ActivationThemeModel.Colors =
@@ -98,6 +121,12 @@ private fun ActivationTheme.Colors.toModel(): ActivationThemeModel.Colors =
         error = error,
         warning = warning,
         border = border,
+        accent = accent,
+        surfaceBrand = surfaceBrand,
+        textOnPrimary = textOnPrimary,
+        textOnSecondary = textOnSecondary,
+        tagSurface = tagSurface,
+        tagText = tagText,
     )
 
 private fun ActivationThemeModel.Shapes.toLocal(): ActivationTheme.Shapes =
@@ -109,13 +138,13 @@ private fun ActivationTheme.Shapes.toModel(): ActivationThemeModel.Shapes =
 private fun ActivationThemeModel.Typography.toLocal(): ActivationTheme.Typography =
     ActivationTheme.Typography(
         sizeScaleFactor = sizeScaleFactor,
-        fontFamily = fontFamily?.toString()
+        fontFamily = fontFamily?.toString(),
     )
 
 private fun ActivationTheme.Typography.toModel(): ActivationThemeModel.Typography =
     ActivationThemeModel.Typography(
         sizeScaleFactor = sizeScaleFactor,
-        fontFamily = fontFamily?.decodeFontFamilyOrNull()
+        fontFamily = fontFamily?.decodeFontFamilyOrNull(),
     )
 
 private fun String.decodeFontFamilyOrNull(): FontFamily? =
@@ -148,6 +177,14 @@ internal fun ActivationThemeModel.toLocal(): ActivationTheme =
             missedEarningsIcon = icons.missedEarningsIcon?.toLocal(),
             boostIcon = icons.boostIcon?.toLocal(),
             niceScanIcon = icons.niceScanIcon?.toLocal(),
+            editMissedEarning = icons.editMissedEarning?.toLocal(),
+            submitMissedEarnings = icons.submitMissedEarnings?.toLocal(),
+            addMissedEarnings = icons.addMissedEarnings?.toLocal(),
+            reportMissedEarnings = icons.reportMissedEarnings?.toLocal(),
+            calendarMissedEarnings = icons.calendarMissedEarnings?.toLocal(),
+            submitMissedEarningsSuccess = icons.submitMissedEarningsSuccess?.toLocal(),
+            submitMissedEarningsError = icons.submitMissedEarningsError?.toLocal(),
+            infoIcon = icons.infoIcon?.toLocal(),
         ),
     )
 
@@ -171,6 +208,14 @@ internal fun ActivationTheme.toModel(): ActivationThemeModel =
             missedEarningsIcon = icons.missedEarningsIcon?.toModel(),
             boostIcon = icons.boostIcon?.toModel(),
             niceScanIcon = icons.niceScanIcon?.toModel(),
+            editMissedEarning = icons.editMissedEarning?.toModel(),
+            submitMissedEarnings = icons.submitMissedEarnings?.toModel(),
+            addMissedEarnings = icons.addMissedEarnings?.toModel(),
+            reportMissedEarnings = icons.reportMissedEarnings?.toModel(),
+            calendarMissedEarnings = icons.calendarMissedEarnings?.toModel(),
+            submitMissedEarningsSuccess = icons.submitMissedEarningsSuccess?.toModel(),
+            submitMissedEarningsError = icons.submitMissedEarningsError?.toModel(),
+            infoIcon = icons.infoIcon?.toModel(),
         ),
     )
 

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/local/ThemesAndAppearanceStorage.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/themes/local/ThemesAndAppearanceStorage.kt
@@ -23,13 +23,17 @@ import kotlinx.serialization.json.Json
  * @property dataStore An optional [DataStore] instance used to persist preferences. If null,
  *   persistence is disabled.
  */
-internal class ThemesAndAppearanceStorage(private val dataStore: DataStore<Preferences>? = null) {
-    private val json = Json {
-        ignoreUnknownKeys = true
-        encodeDefaults = true
-        isLenient = true
-    }
+/**
+ * The exact [Json] configuration the storage persists with — file-level so tests can encode/decode
+ * fixtures against the production configuration.
+ */
+internal val themeStorageJson = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+    isLenient = true
+}
 
+internal class ThemesAndAppearanceStorage(private val dataStore: DataStore<Preferences>? = null) {
     init {
         Logger.d(TAG) {
             val persisted = dataStore != null
@@ -62,7 +66,7 @@ internal class ThemesAndAppearanceStorage(private val dataStore: DataStore<Prefe
             Logger.d(TAG) { "save: no DataStore, no-op" }
             return
         }
-        dataStore.edit { prefs -> prefs[KEY_ACTIVATION_THEME] = json.encodeToString(theme.toLocal()) }
+        dataStore.edit { prefs -> prefs[KEY_ACTIVATION_THEME] = themeStorageJson.encodeToString(theme.toLocal()) }
         Logger.d(TAG) { "save: persisted theme" }
     }
 
@@ -71,7 +75,7 @@ internal class ThemesAndAppearanceStorage(private val dataStore: DataStore<Prefe
             Logger.d(TAG) { "save: no DataStore, no-op" }
             return
         }
-        dataStore.edit { prefs -> prefs[KEY_ACTIVATION_APPEARANCE] = json.encodeToString(appearance.toLocal()) }
+        dataStore.edit { prefs -> prefs[KEY_ACTIVATION_APPEARANCE] = themeStorageJson.encodeToString(appearance.toLocal()) }
         Logger.d(TAG) { "save: persisted appearance" }
     }
 
@@ -103,14 +107,14 @@ internal class ThemesAndAppearanceStorage(private val dataStore: DataStore<Prefe
     }
 
     private fun String.decodeThemeOrNull(): ActivationTheme? =
-        runCatching { json.decodeFromString<com.actualplatform.android.activation.development.ui.themes.local.ActivationTheme>(this).toModel() }
+        runCatching { themeStorageJson.decodeFromString<com.actualplatform.android.activation.development.ui.themes.local.ActivationTheme>(this).toModel() }
             .onFailure { e ->
                 Logger.d(TAG) { "decodeThemeOrNull: failed to decode theme JSON — $e" }
             }
             .getOrNull()
 
     private fun String.decodeAppearanceOrNull(): ActivationAppearance? =
-        runCatching { json.decodeFromString<com.actualplatform.android.activation.development.ui.themes.local.ActivationAppearance>(this).toModel() }
+        runCatching { themeStorageJson.decodeFromString<com.actualplatform.android.activation.development.ui.themes.local.ActivationAppearance>(this).toModel() }
             .onFailure { e ->
                 Logger.d(TAG) { "decodeAppearanceOrNull: failed to decode appearance JSON — $e" }
             }

--- a/blinkreceipt-demo/ActualActivation/src/main/res/values/strings.xml
+++ b/blinkreceipt-demo/ActualActivation/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="activations_themes_section_loading">Loading</string>
     <string name="activations_themes_section_error_modal">Error Modal</string>
     <string name="activations_themes_section_receipt_summary">Receipt Summary</string>
+    <string name="activations_themes_section_missed_earnings">Missed Earnings</string>
     <string name="activations_themes_label_light">Light</string>
     <string name="activations_themes_label_dark">Dark</string>
     <string name="activations_themes_label_override_dark">Override dark colors</string>

--- a/blinkreceipt-demo/ActualActivation/src/test/java/com/actualplatform/android/activation/development/ui/themes/local/ActivationAppearancesTest.kt
+++ b/blinkreceipt-demo/ActualActivation/src/test/java/com/actualplatform/android/activation/development/ui/themes/local/ActivationAppearancesTest.kt
@@ -1,0 +1,88 @@
+package com.actualplatform.android.activation.development.ui.themes.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import com.actualplatform.activation.theming.ActivationAppearance as ActivationAppearanceModel
+
+/**
+ * Serialization round-trip and legacy-payload tests for the local [ActivationAppearance] model,
+ * run against the production [themeStorageJson] configuration.
+ */
+public class ActivationAppearancesTest {
+
+    @Test
+    public fun `verify legacy labels only payload decodes and preserves labels`() {
+        val legacy =
+            """{"offersWall":{"labels":{"scanLabel":"Scan!","scanExtendedLabel":"Scan a receipt"}}}"""
+
+        val model = themeStorageJson.decodeFromString<ActivationAppearance>(legacy).toModel()
+
+        assertEquals("Scan!", model.offersWall.labels.scanLabel)
+        assertEquals("Scan a receipt", model.offersWall.labels.scanExtendedLabel)
+        assertEquals(ActivationAppearanceModel.OffersWall.Colors(), model.offersWall.colors)
+        assertEquals(ActivationAppearanceModel.Loading.Colors(), model.loading.colors)
+        assertEquals(ActivationAppearanceModel.ErrorModal.Colors(), model.errorModal.colors)
+        assertEquals(ActivationAppearanceModel.ReceiptSummary.Colors(), model.receiptSummary.colors)
+        assertEquals(ActivationAppearanceModel.MissedEarnings.Colors(), model.missedEarnings.colors)
+    }
+
+    @Test
+    public fun `verify round trip preserves overrides per scope`() {
+        val model =
+            ActivationAppearanceModel(
+                offersWall =
+                ActivationAppearanceModel.OffersWall(
+                    colors =
+                    ActivationAppearanceModel.OffersWall.Colors(
+                        offerWallBackground = 0xFF102030L,
+                    ),
+                    labels = ActivationAppearanceModel.OffersWall.Labels(scanLabel = "Scan!"),
+                ),
+                loading =
+                ActivationAppearanceModel.Loading(
+                    colors =
+                    ActivationAppearanceModel.Loading.Colors(
+                        adLoadingLoadingBarLabel = 0xFF112233L,
+                    ),
+                ),
+                errorModal =
+                ActivationAppearanceModel.ErrorModal(
+                    colors =
+                    ActivationAppearanceModel.ErrorModal.Colors(
+                        errorModalBackground = 0xFF223344L,
+                    ),
+                ),
+                receiptSummary =
+                ActivationAppearanceModel.ReceiptSummary(
+                    colors =
+                    ActivationAppearanceModel.ReceiptSummary.Colors(
+                        postScanHeaderBackground = 0xFF334455L,
+                    ),
+                ),
+                missedEarnings =
+                ActivationAppearanceModel.MissedEarnings(
+                    colors =
+                    ActivationAppearanceModel.MissedEarnings.Colors(
+                        missedEarningsNavigationTitleLabel = 0xFF445566L,
+                    ),
+                ),
+            )
+
+        val decoded =
+            themeStorageJson.decodeFromString<ActivationAppearance>(
+                themeStorageJson.encodeToString(model.toLocal()),
+            )
+
+        assertEquals(model, decoded.toModel())
+    }
+
+    @Test
+    public fun `verify default appearance round trips to default`() {
+        val decoded =
+            themeStorageJson.decodeFromString<ActivationAppearance>(
+                themeStorageJson.encodeToString(ActivationAppearanceModel().toLocal()),
+            )
+
+        assertEquals(ActivationAppearanceModel(), decoded.toModel())
+    }
+}

--- a/blinkreceipt-demo/ActualActivation/src/test/java/com/actualplatform/android/activation/development/ui/themes/local/ActivationThemesTest.kt
+++ b/blinkreceipt-demo/ActualActivation/src/test/java/com/actualplatform/android/activation/development/ui/themes/local/ActivationThemesTest.kt
@@ -1,0 +1,95 @@
+package com.actualplatform.android.activation.development.ui.themes.local
+
+import com.actualplatform.activation.theming.ActivationColorDefaults
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import com.actualplatform.activation.theming.ActivationTheme as ActivationThemeModel
+
+/**
+ * Serialization round-trip and legacy-payload tests for the local [ActivationTheme] model, run
+ * against the production [themeStorageJson] configuration.
+ */
+public class ActivationThemesTest {
+
+    @Test
+    public fun `verify legacy colors payload missing new tokens decodes with derived defaults`() {
+        val palette =
+            ActivationColorDefaults.lightColors(
+                primary = CUSTOM_PRIMARY,
+                surfaceAccent = CUSTOM_SURFACE_ACCENT,
+                textAccent = CUSTOM_TEXT_ACCENT,
+                textInverse = CUSTOM_TEXT_INVERSE,
+            )
+        // darkColors == lightColors folds local darkColors to null, matching a legacy payload.
+        val model = ActivationThemeModel(lightColors = palette, darkColors = palette)
+
+        // Strip the six new-token keys from "colors" to simulate a payload persisted before
+        // the tokens existed.
+        val fullJson =
+            themeStorageJson
+                .parseToJsonElement(themeStorageJson.encodeToString(model.toLocal()))
+                .jsonObject
+        val legacyColors =
+            JsonObject(fullJson.getValue("colors").jsonObject.filterKeys { it !in NEW_TOKEN_KEYS })
+        val legacyJson = JsonObject(fullJson + ("colors" to legacyColors))
+
+        val decoded = themeStorageJson.decodeFromString<ActivationTheme>(legacyJson.toString())
+
+        val colors = decoded.colors
+        assertEquals(CUSTOM_PRIMARY, colors.primary)
+        assertEquals(CUSTOM_PRIMARY, colors.accent)
+        assertEquals(CUSTOM_PRIMARY, colors.surfaceBrand)
+        assertEquals(CUSTOM_TEXT_INVERSE, colors.textOnPrimary)
+        assertEquals(CUSTOM_TEXT_INVERSE, colors.textOnSecondary)
+        assertEquals(CUSTOM_SURFACE_ACCENT, colors.tagSurface)
+        assertEquals(CUSTOM_TEXT_ACCENT, colors.tagText)
+    }
+
+    @Test
+    public fun `verify explicit null darkColors decodes to null and toModel folds dark to light`() {
+        val decoded = themeStorageJson.decodeFromString<ActivationTheme>("""{"darkColors":null}""")
+
+        assertNull(decoded.darkColors)
+        val model = decoded.toModel()
+        assertEquals(model.lightColors, model.darkColors)
+    }
+
+    @Test
+    public fun `verify missing darkColors key decodes to null`() {
+        val decoded = themeStorageJson.decodeFromString<ActivationTheme>("{}")
+
+        assertNull(decoded.darkColors)
+    }
+
+    @Test
+    public fun `verify round trip preserves distinct light and dark palettes including new tokens`() {
+        val model =
+            ActivationThemeModel(
+                lightColors =
+                ActivationColorDefaults.lightColors(
+                    primary = 0xFF111111L,
+                    tagSurface = 0xFF333333L,
+                ),
+                darkColors = ActivationColorDefaults.darkColors(primary = 0xFF222222L),
+            )
+
+        val decoded =
+            themeStorageJson.decodeFromString<ActivationTheme>(
+                themeStorageJson.encodeToString(model.toLocal()),
+            )
+
+        assertEquals(model, decoded.toModel())
+    }
+
+    private companion object {
+        const val CUSTOM_PRIMARY = 0xFFAABBCCL
+        const val CUSTOM_SURFACE_ACCENT = 0xFF112233L
+        const val CUSTOM_TEXT_ACCENT = 0xFF445566L
+        const val CUSTOM_TEXT_INVERSE = 0xFF778899L
+        val NEW_TOKEN_KEYS =
+            setOf("accent", "surfaceBrand", "textOnPrimary", "textOnSecondary", "tagSurface", "tagText")
+    }
+}

--- a/blinkreceipt-demo/versions.gradle
+++ b/blinkreceipt-demo/versions.gradle
@@ -24,10 +24,10 @@ buildscript {
 
     ext.versions = [
             'minSdk'           : 24,
-            'compileSdk'       : 36,
+            'compileSdk'       : 37,
             'targetSdk'        : 36,
             'androidTestRunner': '1.6.2',
-            'buildTools'       : '36.0.0',
+            'buildTools'       : '37.0.0',
             'material'         : '1.13.0',
             'kotlin'           : '2.2.21',
             'easyPermissions'  : '3.0.0',

--- a/blinkreceipt-demo/versions.gradle
+++ b/blinkreceipt-demo/versions.gradle
@@ -35,8 +35,8 @@ buildscript {
             "agp"              : '9.2.1',
             'testRunner'       : '1.4.0',
             'espresso'         : '3.7.0',
-            'bom'              : '2.2.0',
-            'activation'       : '1.1.0',
+            'bom'              : '2.2.1',
+            'activation'       : '1.1.1',
             'tasks'            : '18.2.0',
             'logcat'           : '0.1',
             'msal'             : '5.4.0',
@@ -48,6 +48,6 @@ buildscript {
             'colorPicker'      : '1.1.2',
             'versionMajor'     : 2,
             'versionMinor'     : 2,
-            'versionPatch'     : 0
+            'versionPatch'     : 1
     ]
 }

--- a/blinkreceipt-digital-analytics/RELEASE_NOTES.md
+++ b/blinkreceipt-digital-analytics/RELEASE_NOTES.md
@@ -85,3 +85,6 @@
 
 ## 2.2.0
 - Stability fixes and improvements
+
+## 2.2.1
+- Stability fixes and improvements

--- a/blinkreceipt-digital/RELEASE_NOTES.md
+++ b/blinkreceipt-digital/RELEASE_NOTES.md
@@ -408,3 +408,6 @@
 
 ## 2.2.0
 - Stability fixes and improvements
+
+## 2.2.1
+- Stability fixes and improvements

--- a/blinkreceipt-earnings/RELEASE_NOTES.md
+++ b/blinkreceipt-earnings/RELEASE_NOTES.md
@@ -335,3 +335,6 @@
 
 ## 2.2.0
 - Stability fixes and improvements
+
+## 2.2.1
+- Stability fixes and improvements

--- a/blinkreceipt-logcat/RELEASE_NOTES.md
+++ b/blinkreceipt-logcat/RELEASE_NOTES.md
@@ -86,3 +86,6 @@
 
 ## 2.2.0
 - Stability fixes and improvements
+
+## 2.2.1
+- Stability fixes and improvements

--- a/blinkreceipt-recognizer/RELEASE_NOTES.md
+++ b/blinkreceipt-recognizer/RELEASE_NOTES.md
@@ -810,3 +810,6 @@ Blink Receipt Recognizer
 - Stability Improvements 
   - Resolved a crash that could occur when processing specific receipt formats. 
   - General performance and stability enhancements.
+
+## 2.2.1
+- Stability fixes and improvements

--- a/blinkreceipt-security/RELEASE_NOTES.md
+++ b/blinkreceipt-security/RELEASE_NOTES.md
@@ -86,3 +86,6 @@
 
 ## 2.2.0
 - Stability fixes and improvements
+
+## 2.2.1
+- Stability fixes and improvements

--- a/blinkreceipt-surveys/RELEASE_NOTES.md
+++ b/blinkreceipt-surveys/RELEASE_NOTES.md
@@ -297,3 +297,7 @@
 
 ## 2.2.0
 - Stability fixes and improvements
+
+## 2.2.1
+- Stability fixes and improvements
+

--- a/builtFromCommit.txt
+++ b/builtFromCommit.txt
@@ -1,1 +1,1 @@
-Built from commit e25bb2946e1991b8d2234cd7e626e2e4d793a3d9
+Built from commit 20aea17f573b203b414165637f806895a71cdb1e

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 extra:
   blinkreceipt:
-    release: '2.2.0'
+    release: '2.2.1'
     next_release: '2.3.0'
 site_name: "BlinkReceipt"
 site_url: https://microblink.github.io/blinkreceipt-android/


### PR DESCRIPTION
## Jira Ticket

<!-- Provide Jira ticket number or a link -->


## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Please check the relevant option(s) -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## AI Usage

<!-- Please check exactly ONE of the following options. This helps us track AI-assisted work across the organization. -->

- [ ] AI used
- [ ] AI not used

## Testing

<!-- Describe the tests you ran and any relevant test results -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional context, screenshots, or information that reviewers should know -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SDK module sources are largely unchanged aside from release metadata; risk is confined to demo/QA tooling and build version bumps, not production SDK behavior.
> 
> **Overview**
> This PR cuts **2.2.1** across the BlinkReceipt modules: patch version and BOM/activation pins in `versions.gradle`, **compileSdk/buildTools 37**, docs release in `mkdocs.yml`, and **2.2.1** release-note entries (mostly stability) plus an updated `builtFromCommit.txt`.
> 
> The substantive code changes sit in the **ActualActivation demo**, not the published SDK libraries. **Customize Appearance** grows from a couple of FAB label fields into per-screen collapsible editors for **Offers Wall, Loading, Error Modal, Receipt Summary, and Missed Earnings**, with nullable per-element color overrides wired through new **`AppearanceColorsEditors`** / **`NullableColorPickerRow`** (defaults aligned with **`AppearanceBridge`**). **Apply/Reset** now builds a full `ActivationAppearance`, and **`snapshotFlow`** re-syncs from `Activation.appearance` until the user edits locally to avoid racing async DataStore hydration and wiping saved customizations.
> 
> **Theme & icon QA** picks up new **`ActivationTheme`** tokens (accent, surfaceBrand, textOnPrimary/Secondary, tagSurface/tagText), more **missed-earnings and info** icons, **`textOnPrimary`** for primary buttons, and **`ActivationColorDefaults`** in presets. **DataStore** models mirror the expanded appearance/theme shapes with backward-compatible defaults; **`themeStorageJson`** is shared with new **serialization round-trip / legacy payload** unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 002ccf466562dc2ced13a3b18b4503eba60bc77b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->