### PR TITLE
disable deprecated mkdocs gh actions

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,24 +1,23 @@
 # Deprecated: old BlinkReceipt docs site (https://blinkreceipt.github.io/blinkreceipt-android/).
-# Commented out for now so pushes to master no longer redeploy GitHub Pages.
-# Uncomment to restore publishing.
-#
-# name: BlinkReceipt Docs CI
-# on:
-#   push:
-#     branches:
-#       - master
-# jobs:
-#   mkdocs:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Source Code Checkout
-#         uses: actions/checkout@v3
-#         with:
-#           submodules: 'false'
-#           token: ${{ secrets.GITHUB_TOKEN }}
-#           lfs: 'false'
-#       - uses: actions/setup-python@v2
-#         with:
-#           python-version: 3.x
-#       - run: pip install mkdocs-material mkdocs-macros-plugin
-#       - run: mkdocs gh-deploy --force
+# Current docs: https://docs.actualplatform.com/docs/category/android-1/
+# Push-to-master deploy removed; job kept disabled so this file stays a valid workflow.
+name: BlinkReceipt Docs CI
+on:
+  workflow_dispatch:
+
+jobs:
+  mkdocs:
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Source Code Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: "false"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          lfs: "false"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material mkdocs-macros-plugin
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,20 +1,24 @@
-name: BlinkReceipt Docs CI
-on:
-  push:
-    branches:
-      - master
-jobs:
-  mkdocs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Source Code Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: 'false'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          lfs: 'false'
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.x
-      - run: pip install mkdocs-material mkdocs-macros-plugin
-      - run: mkdocs gh-deploy --force
+# Deprecated: old BlinkReceipt docs site (https://blinkreceipt.github.io/blinkreceipt-android/).
+# Commented out for now so pushes to master no longer redeploy GitHub Pages.
+# Uncomment to restore publishing.
+#
+# name: BlinkReceipt Docs CI
+# on:
+#   push:
+#     branches:
+#       - master
+# jobs:
+#   mkdocs:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Source Code Checkout
+#         uses: actions/checkout@v3
+#         with:
+#           submodules: 'false'
+#           token: ${{ secrets.GITHUB_TOKEN }}
+#           lfs: 'false'
+#       - uses: actions/setup-python@v2
+#         with:
+#           python-version: 3.x
+#       - run: pip install mkdocs-material mkdocs-macros-plugin
+#       - run: mkdocs gh-deploy --force

--- a/blinkreceipt-digital-analytics/README.md
+++ b/blinkreceipt-digital-analytics/README.md
@@ -1,1 +1,6 @@
-## The documentation for the Digital Analytics SDK has been moved to our [github pages](https://blinkreceipt.github.io/blinkreceipt-android/)
+## Documentation
+
+Android docs are on the Actual Platform site:  
+https://docs.actualplatform.com/docs/category/android-1/
+
+<!-- Deprecated: https://blinkreceipt.github.io/blinkreceipt-android/ -->

--- a/blinkreceipt-logcat/README.md
+++ b/blinkreceipt-logcat/README.md
@@ -1,1 +1,6 @@
-## The documentation for the Logging SDK has been moved to our [github pages](https://blinkreceipt.github.io/blinkreceipt-android/)
+## Documentation
+
+Android docs are on the Actual Platform site:  
+https://docs.actualplatform.com/docs/category/android-1/
+
+<!-- Deprecated: https://blinkreceipt.github.io/blinkreceipt-android/ -->

--- a/blinkreceipt-security/README.md
+++ b/blinkreceipt-security/README.md
@@ -1,1 +1,6 @@
-## The documentation for the Security SDK has been moved to our [github pages](https://blinkreceipt.github.io/blinkreceipt-android/)
+## Documentation
+
+Android docs are on the Actual Platform site:  
+https://docs.actualplatform.com/docs/category/android-1/
+
+<!-- Deprecated: https://blinkreceipt.github.io/blinkreceipt-android/ -->


### PR DESCRIPTION
## Jira Ticket

<!-- Provide Jira ticket number or a link -->


## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Please check the relevant option(s) -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## AI Usage

<!-- Please check exactly ONE of the following options. This helps us track AI-assisted work across the organization. -->

- [ ] AI used
- [ ] AI not used

## Testing

<!-- Describe the tests you ran and any relevant test results -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional context, screenshots, or information that reviewers should know -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI-only changes; no runtime SDK or application behavior is affected.
> 
> **Overview**
> **Stops automatic publishing** of the legacy BlinkReceipt GitHub Pages docs by changing `.github/workflows/mkdocs.yml`: the `push` to `master` trigger is removed, the workflow is only available via `workflow_dispatch`, and the `mkdocs` job is hard-disabled with `if: false` while keeping the file valid. Comments document that the old site is deprecated and **https://docs.actualplatform.com/docs/category/android-1/** is canonical.
> 
> **README doc links** in `blinkreceipt-digital-analytics`, `blinkreceipt-logcat`, and `blinkreceipt-security` are updated from the old github.io pages URL to the Actual Platform Android docs, with the previous link left in an HTML comment as deprecated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 337dd1e4e60f2549f5d4cba29653e1bceaa0ee2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->