### PR TITLE
Release/2.3.1

### DIFF
--- a/blinkreceipt-account-linking/RELEASE_NOTES.md
+++ b/blinkreceipt-account-linking/RELEASE_NOTES.md
@@ -423,3 +423,9 @@ accountLinkingClient.orders(
 
 ## 2.3.0
 - Stability fixes and improvements
+
+## 2.3.1
+- Hardened the published R8/ProGuard rules so the generic signatures Gson reads off `TypeToken` survive minification. Nothing changes for integrations; the rules keep Gson's type resolution correct under R8 full mode, which the SDK now builds with.
+- Updated Gson to 2.14.0. It is now declared explicitly by this module rather than inherited transitively, so the version no longer depends on another library's dependency graph.
+- Updated `androidx.work` to 2.11.2, which brings Room 2.7.0 and its corrected R8 keep rule, and published that rule alongside it. Under R8 full mode — the default for an app — the older rule let R8 drop the constructor WorkManager's generated database is created with, so an integrating app minifying in full mode could crash on launch with `NoSuchMethodException: androidx.work.impl.WorkDatabase_Impl.<init> []`. No integration changes are required.
+- Stability fixes and improvements

--- a/blinkreceipt-camera-ui/RELEASE_NOTES.md
+++ b/blinkreceipt-camera-ui/RELEASE_NOTES.md
@@ -250,3 +250,6 @@
 
 ## 2.3.0
 - Stability fixes and improvements
+
+## 2.3.1
+- Stability fixes and improvements

--- a/blinkreceipt-camera-ui/RELEASE_NOTES.md
+++ b/blinkreceipt-camera-ui/RELEASE_NOTES.md
@@ -252,4 +252,6 @@
 - Stability fixes and improvements
 
 ## 2.3.1
+- Refreshed the Camera Preview UI/UX with a new one-time fullscreen guide shown before the camera opens on first launch, a new hint button with a "How to scan a receipt" dialog, and a refreshed default accent color, tooltip, and button styling.
+  - **BREAKING CHANGE**: Several resources behind the previous camera UI were removed as part of the redesign — `recognizer_receipt_edge`, `recognizer_camera_initial_instruction`, `recognizer_move_closer_suggestion`, and `recognizer_move_further_suggestion` strings; the `default_secondary_button_background`, `ic_torch_selector`, `primary_secondary_color_selector`, and `tooltip_secondary_action_button_selector` drawables; and the `BlinkTooltip` `declare-styleable` (its attributes are now top-level `<attr>` elements, so `R.styleable.BlinkTooltip` no longer exists). Overrides of the removed strings/drawables no longer take effect, and direct references to the removed drawables or styleable will not compile.
 - Stability fixes and improvements

--- a/blinkreceipt-camera/RELEASE_NOTES.md
+++ b/blinkreceipt-camera/RELEASE_NOTES.md
@@ -327,3 +327,6 @@
 
 ## 2.3.0
 - Stability fixes and improvements
+
+## 2.3.1
+- Stability fixes and improvements

--- a/blinkreceipt-core/RELEASE_NOTES.md
+++ b/blinkreceipt-core/RELEASE_NOTES.md
@@ -382,3 +382,8 @@
 
 ## 2.3.0
 - Stability fixes and improvements
+
+## 2.3.1
+- Updated Gson to 2.14.0. It is now declared explicitly by this module rather than inherited transitively, so the version no longer depends on another library's dependency graph.
+- Updated `androidx.work` to 2.11.2, which brings Room 2.7.0 and its corrected R8 keep rule, and published that rule alongside it. Under R8 full mode — the default for an app — the older rule let R8 drop the constructor WorkManager's generated database is created with, so an integrating app minifying in full mode could crash on launch with `NoSuchMethodException: androidx.work.impl.WorkDatabase_Impl.<init> []`. No integration changes are required.
+- Stability fixes and improvements

--- a/blinkreceipt-demo/ActualActivation/build.gradle
+++ b/blinkreceipt-demo/ActualActivation/build.gradle
@@ -96,6 +96,7 @@ dependencies {
     implementation libs.androidx.navigation3.runtime
     implementation libs.androidx.navigation3.ui
     implementation libs.androidx.lifecycle.viewmodel.navigation3
+    implementation libs.androidx.lifecycle.runtime.compose
 
     // Activation theming editor (DataStore persistence, color picker dialog, icon thumbnails)
     implementation libs.androidx.datastore.preferences

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/ActivationActivity.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/ActivationActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.togetherWith
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -43,7 +42,6 @@ import com.actualplatform.activation.ScanReward
 import com.actualplatform.activation.models.PlacementLayout
 import com.actualplatform.activation.networking.HttpEnvironment
 import com.actualplatform.activation.networking.TestOptions
-import com.actualplatform.activation.theming.LocalActivationDarkTheme
 import com.actualplatform.android.activation.development.R
 import com.actualplatform.android.activation.development.ui.themes.ThemesAndIconEditorScreen
 import com.actualplatform.android.activation.development.ui.themes.local.ThemesAndAppearanceStorage
@@ -509,6 +507,8 @@ private data class RewardsData(
         ScanFinished,
         Promo,
         Boost,
+        BoostCreditEarned,
+        BoostCreditApplied,
     }
 }
 
@@ -519,6 +519,8 @@ private fun Rewards.toData(): RewardsData =
             is Rewards.ScanFinished -> RewardsData.Type.ScanFinished
             is Rewards.Promotion -> RewardsData.Type.Promo
             is Rewards.Boost -> RewardsData.Type.Boost
+            is Rewards.BoostCreditEarned -> RewardsData.Type.BoostCreditEarned
+            is Rewards.BoostCreditApplied -> RewardsData.Type.BoostCreditApplied
         },
         amount = this.amount.value,
         blinkReceiptId = this.blinkReceiptId,
@@ -530,6 +532,8 @@ private fun RewardsData.toModel(): Rewards =
         RewardsData.Type.ScanFinished -> Rewards.ScanFinished(this.blinkReceiptId, RewardPoint(this.amount))
         RewardsData.Type.Promo -> Rewards.Promotion(this.blinkReceiptId, RewardPoint(this.amount))
         RewardsData.Type.Boost -> Rewards.Boost(this.blinkReceiptId, RewardPoint(this.amount))
+        RewardsData.Type.BoostCreditEarned -> Rewards.BoostCreditEarned(this.blinkReceiptId, RewardPoint(this.amount))
+        RewardsData.Type.BoostCreditApplied -> Rewards.BoostCreditApplied(this.blinkReceiptId, RewardPoint(this.amount))
     }
 
 /** Reads an enum pref stored by [Enum.name], falling back to [default] for missing/unknown values. */

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/HomeScreen.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/HomeScreen.kt
@@ -66,6 +66,8 @@ internal fun HomeScreen(
             // Read-only settings summary
             SettingsSummary(settings = settings)
 
+            RegistrationStateBanner()
+
             Spacer(modifier = Modifier.height(16.dp))
             HorizontalDivider()
             Spacer(modifier = Modifier.height(16.dp))
@@ -107,6 +109,8 @@ internal fun HomeScreen(
                         is Rewards.ScanFinished -> "Scan"
                         is Rewards.Promotion -> "Promotion"
                         is Rewards.Boost -> "Boost"
+                        is Rewards.BoostCreditEarned -> "Credit Earned"
+                        is Rewards.BoostCreditApplied -> "Credit Applied"
                     }
                     Text(
                         text = "${index + 1}. $label: +${String.format(java.util.Locale.US, "%.2f", reward.amount.value)}\t${reward.blinkReceiptId}",

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/RegistrationStateBanner.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/RegistrationStateBanner.kt
@@ -1,0 +1,63 @@
+package com.actualplatform.android.activation.development.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.actualplatform.activation.ActivationClient
+import com.actualplatform.activation.RegistrationState
+
+@Composable
+internal fun RegistrationStateBanner(modifier: Modifier = Modifier) {
+    val state by ActivationClient.instance.registrationState.collectAsStateWithLifecycle()
+
+    val label: String
+    val bgColor: Color
+    val textColor: Color
+    when (val current = state) {
+        is RegistrationState.Idle -> {
+            label = "⚪ Registration: Idle"
+            bgColor = MaterialTheme.colorScheme.surfaceVariant
+            textColor = MaterialTheme.colorScheme.onSurfaceVariant
+        }
+        is RegistrationState.Registering -> {
+            label = "🟡 Registration: Registering…"
+            bgColor = MaterialTheme.colorScheme.secondaryContainer
+            textColor = MaterialTheme.colorScheme.onSecondaryContainer
+        }
+        is RegistrationState.Registered -> {
+            label = "🟢 Registration: Registered (clientId=${current.clientId})"
+            bgColor = MaterialTheme.colorScheme.primaryContainer
+            textColor = MaterialTheme.colorScheme.onPrimaryContainer
+        }
+        is RegistrationState.Exception -> {
+            label = "🔴 Registration: Failed (${current.exception})"
+            bgColor = MaterialTheme.colorScheme.errorContainer
+            textColor = MaterialTheme.colorScheme.onErrorContainer
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(bgColor)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            fontFamily = FontFamily.Monospace,
+            color = textColor,
+            softWrap = true,
+        )
+    }
+}

--- a/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/SettingsScreen.kt
+++ b/blinkreceipt-demo/ActualActivation/src/main/java/com/actualplatform/android/activation/development/ui/SettingsScreen.kt
@@ -221,7 +221,8 @@ private fun EditModeContent(
         Spacer(modifier = Modifier.height(24.dp))
 
         // DO NOT SHOW Environment selection. It is NOT intended for public usage.
-        // DO NOT SHOW TestOptions.TestAds. It is no longer recommended.
+        // The Test Ads option is gone: TestOptions no longer declares an Ads value as of
+        // Activation 1.1.x, so Test Mode is the only test option left to surface.
         TestOptionsSection(
             testMode = testMode,
             onTestModeChange = { testMode = it },

--- a/blinkreceipt-demo/ActualActivation/src/main/res/values/strings.xml
+++ b/blinkreceipt-demo/ActualActivation/src/main/res/values/strings.xml
@@ -8,7 +8,6 @@
     <string name="activations_editText_hint_phone">Phone Number</string>
     <string name="activations_section_user_identity">User Identity</string>
     <string name="activations_section_test_options">Test Options</string>
-    <string name="activations_label_test_ads">Test Ads</string>
     <string name="activations_label_test_mode">Test Mode</string>
     <string name="activations_section_debug_placements">Debug Force Placements</string>
     <string name="activations_section_scan_reward">Scan Reward</string>

--- a/blinkreceipt-demo/gradle/libs.versions.toml
+++ b/blinkreceipt-demo/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ androidxCore = "1.17.0"
 androidxDatastore = "1.1.1"
 androidxFragment = "1.8.1"
 androidxLifecycle = "2.8.3"
+androidxLifecycleRuntimeCompose = "2.10.0"
 androidxLifecycleViewmodelNav3 = "2.10.0"
 androidxNavigation3 = "1.0.1"
 androidxRecyclerview = "1.3.2"
@@ -59,6 +60,7 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidxDatastore" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidxFragment" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycleRuntimeCompose" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "androidxLifecycleViewmodelNav3" }
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "androidxNavigation3" }

--- a/blinkreceipt-demo/gradle/libs.versions.toml
+++ b/blinkreceipt-demo/gradle/libs.versions.toml
@@ -35,8 +35,8 @@ androidxTestRunner = "1.6.2"
 junit = "4.13.2"
 
 # BlinkReceipt / Actual Platform
-blinkreceiptBom = "2.3.0"
-activationBom = "1.1.1"
+blinkreceiptBom = "2.3.1"
+activationBom = "1.1.2"
 
 # Third party
 barcodeScanning = "17.3.0"

--- a/blinkreceipt-digital-analytics/RELEASE_NOTES.md
+++ b/blinkreceipt-digital-analytics/RELEASE_NOTES.md
@@ -94,3 +94,9 @@
 
 ## 2.3.0
 - Stability fixes and improvements
+
+## 2.3.1
+- Updated Gson to 2.14.0. It is now declared explicitly by this module rather than inherited transitively, so the version no longer depends on another library's dependency graph.
+- Hardened the published R8/ProGuard rules so the `WorkerService` companion object keeps its name in the release AAR, matching the field that references it. Nothing was reachable through this in 2.3.0, so no integration changes are required.
+- Updated `androidx.work` to 2.11.2, which brings Room 2.7.0 and its corrected R8 keep rule, and published that rule alongside it. Under R8 full mode — the default for an app — the older rule let R8 drop the constructor WorkManager's generated database is created with, so an integrating app minifying in full mode could crash on launch with `NoSuchMethodException: androidx.work.impl.WorkDatabase_Impl.<init> []`. No integration changes are required.
+- Stability fixes and improvements

--- a/blinkreceipt-digital/RELEASE_NOTES.md
+++ b/blinkreceipt-digital/RELEASE_NOTES.md
@@ -425,3 +425,9 @@
   - **Initial provider scope:** Gmail IMAP accounts with a non-empty username. Check any account with `AutoScrapeClient.isAutoScrapeAccount(credentials)`.
   - See the [Automated Scrape](https://microblink.github.io/blinkreceipt-android/digital_auto_scrape/) guide for setup, Kotlin and Java samples, best practices, and troubleshooting.
 - Stability fixes and improvements
+
+## 2.3.1
+- Updated Gson to 2.14.0. It is now declared explicitly by this module rather than inherited transitively, so the version no longer depends on another library's dependency graph.
+- **Fixed: calling an `AutoScrapeClient` companion member from Kotlin threw `NoSuchFieldError` at runtime.** In the 2.3.0 AAR the companion object had been renamed while the field referencing it kept its original name, so `AutoScrapeClient.clampInterval()`, `isAutoScrapeAccount()`, `decide()` and `aggregate()` compiled cleanly and then failed the first time they ran. The `DEFAULT_INTERVAL_HOURS` and `MIN_INTERVAL_HOURS` constants were unaffected (the compiler inlines them), as were Java callers. No integration changes are required, the example in the [Automated Scrape](https://microblink.github.io/blinkreceipt-android/digital_auto_scrape/) guide now works as written, and any local workaround that re-implemented the interval clamp can be replaced with the SDK call again.
+- Updated `androidx.work` to 2.11.2, which brings Room 2.7.0 and its corrected R8 keep rule, and published that rule alongside it. Under R8 full mode — the default for an app — the older rule let R8 drop the constructor WorkManager's generated database is created with, so an integrating app minifying in full mode could crash on launch with `NoSuchMethodException: androidx.work.impl.WorkDatabase_Impl.<init> []`. No integration changes are required.
+- Stability fixes and improvements

--- a/blinkreceipt-earnings/RELEASE_NOTES.md
+++ b/blinkreceipt-earnings/RELEASE_NOTES.md
@@ -344,3 +344,6 @@
 
 ## 2.3.0
 - Stability fixes and improvements
+
+## 2.3.1
+- Stability fixes and improvements

--- a/blinkreceipt-logcat/RELEASE_NOTES.md
+++ b/blinkreceipt-logcat/RELEASE_NOTES.md
@@ -95,3 +95,7 @@
 
 ## 2.3.0
 - Stability fixes and improvements
+
+## 2.3.1
+- Hardened the published R8/ProGuard rules so the `LogEvent` companion object keeps its name in the release AAR, matching the field that references it. Nothing was reachable through this in 2.3.0 — `LogEvent.NONE` is a `@JvmField` member resolved on the outer class — so no integration changes are required.
+- Stability fixes and improvements

--- a/blinkreceipt-recognizer/RELEASE_NOTES.md
+++ b/blinkreceipt-recognizer/RELEASE_NOTES.md
@@ -825,3 +825,8 @@ Blink Receipt Recognizer
 - `RecognizerView.confirmPicture()` now reports a terminated session through `CameraRecognizerCallback.onException()` rather than throwing, so a capture callback that arrives after teardown no longer crashes.
 - `RecognizerView.terminate()` now clears the view's scan options, so calls made on a terminated view fail consistently instead of depending on shared session state that another view instance may have already changed.
 - Stability fixes and improvements
+
+## 2.3.1
+- Updated Gson to 2.14.0. It is now declared explicitly by this module rather than inherited transitively, so the version no longer depends on another library's dependency graph.
+- Updated `androidx.work` to 2.11.2, which brings Room 2.7.0 and its corrected R8 keep rule, and published that rule alongside it. Under R8 full mode — the default for an app — the older rule let R8 drop the constructor WorkManager's generated database is created with, so an integrating app minifying in full mode could crash on launch with `NoSuchMethodException: androidx.work.impl.WorkDatabase_Impl.<init> []`. No integration changes are required.
+- Stability fixes and improvements

--- a/blinkreceipt-security/RELEASE_NOTES.md
+++ b/blinkreceipt-security/RELEASE_NOTES.md
@@ -95,3 +95,7 @@
 
 ## 2.3.0
 - Stability fixes and improvements
+
+## 2.3.1
+- Hardened the published R8/ProGuard rules so the `Crypto` and `License` companion objects keep their names in the release AAR, matching the field that references them. Nothing was reachable through this in 2.3.0 — `Crypto.NONE` and `License.NONE` are `@JvmField` members resolved on the outer class — so no integration changes are required.
+- Stability fixes and improvements

--- a/blinkreceipt-surveys/RELEASE_NOTES.md
+++ b/blinkreceipt-surveys/RELEASE_NOTES.md
@@ -306,3 +306,8 @@
 
 ## 2.3.0
 - Stability fixes and improvements
+
+## 2.3.1
+- Updated Gson to 2.14.0. It is now declared explicitly by this module rather than inherited transitively, so the version no longer depends on another library's dependency graph.
+- Updated `androidx.work` to 2.11.2, which brings Room 2.7.0 and its corrected R8 keep rule, and published that rule alongside it. Under R8 full mode — the default for an app — the older rule let R8 drop the constructor WorkManager's generated database is created with, so an integrating app minifying in full mode could crash on launch with `NoSuchMethodException: androidx.work.impl.WorkDatabase_Impl.<init> []`. No integration changes are required.
+- Stability fixes and improvements


### PR DESCRIPTION
## Jira Ticket

<!-- Provide Jira ticket number or a link -->


## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Please check the relevant option(s) -->

- [x] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## AI Usage

<!-- Please check exactly ONE of the following options. This helps us track AI-assisted work across the organization. -->

- [x] AI used
- [ ] AI not used

## Testing

<!-- Describe the tests you ran and any relevant test results -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional context, screenshots, or information that reviewers should know -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Integrators on camera-ui may break on removed resources; release notes describe R8/WorkManager fixes that affect minified production apps. Demo-only code changes are low risk.
> 
> **Overview**
> **Release 2.3.1** is documented across BlinkReceipt modules. The notes call out dependency and minification fixes (explicit **Gson 2.14.0**, **androidx.work 2.11.2** with Room’s R8 keep rule to avoid `WorkDatabase_Impl` launch crashes under R8 full mode), hardened **R8/ProGuard** rules (Gson `TypeToken`, companion objects in logcat/security/digital-analytics), a **camera-ui** refresh with a **breaking** removal of legacy strings, drawables, and `R.styleable.BlinkTooltip`, and a **digital** fix for Kotlin `NoSuchFieldError` on `AutoScrapeClient` companion APIs.
> 
> The **Actual Activation** demo bumps **blinkreceipt-bom** to `2.3.1` and **activation-bom** to `1.1.2`, adds `lifecycle-runtime-compose`, drops unused `LocalActivationDarkTheme` / `CompositionLocalProvider` wiring, surfaces **`RegistrationState`** via a new home banner, persists and lists **`BoostCreditEarned`** / **`BoostCreditApplied`** rewards, and removes the **Test Ads** UI/string now that Activation’s `TestOptions` no longer includes Ads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c22035328fac3f6e6a30547a4422ac8ff5a74a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->